### PR TITLE
#59 getItems()のコールバック処理、DataObjectのプロパティ宣言の修正

### DIFF
--- a/RakutenRanking/DataObject.swift
+++ b/RakutenRanking/DataObject.swift
@@ -12,13 +12,13 @@ import RealmSwift
 class DataObject: Object {
     
     @objc dynamic var id = 0
-    @objc dynamic var genderType: Int? = nil
-    @objc dynamic var ageType: Int? = nil
+    let genderType = RealmOptional<Int>()
+    let ageType = RealmOptional<Int>()
     @objc dynamic var rank = 0
     @objc dynamic var name = ""
     @objc dynamic var price = ""
     @objc dynamic var sSizeImageUrl = ""
-    @objc dynamic var mSIzeImageUrl = ""
+    @objc dynamic var mSizeImageUrl = ""
     
     override static func primaryKey() -> String? {
         return "id"

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -32,11 +32,13 @@ class RankingManager {
     func getOverallRanking(_ callback: @escaping ([Item]) -> Void) {
         var data = [Item]()
         // Realmから呼び出す処理
-        self.dataGateway.getItems(gender: nil, age: nil, {(array: [Item]) -> Void in
+        self.dataGateway.getItems(gender: nil, age: nil, {[weak self](array: [Item]) -> Void in
+            guard let `self` = self else { return }
             data = array
             // Realmに保存されていなければapi取得
             if data.count == 0 {
-                self.rankingGateway.getOverallRankingRes({(array: [Item]) -> Void in
+                self.rankingGateway.getOverallRankingRes({[weak self](array: [Item]) -> Void in
+                    guard let `self` = self else { return }
                     // arrayをRealmに保存する処理
                     self.dataGateway.saveItems(array: array)
                     // XXXViewControllerにItemを渡す処理

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -30,13 +30,11 @@ class RankingManager {
     
     // 総合ランキング
     func getOverallRanking(_ callback: @escaping ([Item]) -> Void) {
-        var data = [Item]()
         // Realmから呼び出す処理
-        self.dataGateway.getItems(gender: nil, age: nil, {[weak self](array: [Item]) -> Void in
+        self.dataGateway.getItems(gender: nil, age: nil, {[weak self](items: [Item]) -> Void in
             guard let `self` = self else { return }
-            data = array
             // Realmに保存されていなければapi取得
-            if data.count == 0 {
+            if items.count == 0 {
                 self.rankingGateway.getOverallRankingRes({[weak self](array: [Item]) -> Void in
                     guard let `self` = self else { return }
                     // arrayをRealmに保存する処理

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -34,19 +34,19 @@ class RankingManager {
         // Realmから呼び出す処理
         self.dataGateway.getItems(gender: nil, age: nil, {(array: [Item]) -> Void in
             data = array
+            // Realmに保存されていなければapi取得
+            if data.count == 0 {
+                self.rankingGateway.getOverallRankingRes({(array: [Item]) -> Void in
+                    // arrayをRealmに保存する処理
+                    self.dataGateway.saveItems(array: array)
+                    // XXXViewControllerにItemを渡す処理
+                    callback(array)
+                })
+            } else {
+                callback(data)
+            }
         })
-        // TODO: 下記の処理をgetItemsのコールバック処理の中へ移動
-        // Realmに保存されていなければapi取得
-        if data.count == 0 {
-            rankingGateway.getOverallRankingRes({(array: [Item]) -> Void in
-                // arrayをRealmに保存する処理
-                self.dataGateway.saveItems(array: array)
-                // XXXViewControllerにItemを渡す処理
-                callback(array)
-            })
-        } else {
-            callback(data)
-        }
+        
     }
     
     // 男女別ランキング


### PR DESCRIPTION
#59 

- @objc dynamic var hoge: Int? -> let hoge = RealmOptional<Int>()
- typoの修正
- 非同期で処理するために、`DataObjectがなければapi取得する処理` を
  getItems()のコールバック処理内に実装