### PR TITLE
#17 キャッシュクリアボタンの実装

### DIFF
--- a/RakutenRanking/ConfigViewController.swift
+++ b/RakutenRanking/ConfigViewController.swift
@@ -13,6 +13,8 @@ class ConfigViewController: UIViewController, UINavigationControllerDelegate {
     var genderType: Gender = Gender.notKnown
     var ageType: Age = Age.notKnown
     
+    let rankingManager = RankingManager()
+    
     @IBOutlet weak var genderSegment: UISegmentedControl!
     @IBOutlet weak var ageSegment: UISegmentedControl!
 
@@ -25,8 +27,8 @@ class ConfigViewController: UIViewController, UINavigationControllerDelegate {
     }
     
     @IBAction func cacheClearBtn() {
-        // TODO キャッシュクリア処理を実装
-        print("キャッシュクリアボタン押された")
+        // キャッシュクリア処理を実装
+        rankingManager.deleteData()
     }
     
     @IBAction func favoResetBtn() {

--- a/RakutenRanking/DataGateway.swift
+++ b/RakutenRanking/DataGateway.swift
@@ -49,4 +49,11 @@ class DataGateway: DataGatewayProtocol {
         callback(itemArray)
     }
     
+    func deleteDataObject() {
+        // キャッシュクリア
+        try! realm.write{
+            realm.deleteAll()
+        }
+    }
+    
 }

--- a/RakutenRanking/DataGatewayProtocol.swift
+++ b/RakutenRanking/DataGatewayProtocol.swift
@@ -14,4 +14,6 @@ protocol DataGatewayProtocol {
     
     func getItems(gender: Gender, age: Age, _ callback: @escaping ([Item]) -> Void)
     
+    func deleteDataObject()
+    
 }

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -50,5 +50,9 @@ class RankingManager {
         })
     }
     
+    func deleteData() {
+        dataGateway.deleteDataObject()
+    }
+    
 }
 


### PR DESCRIPTION
# issue
#17 

# 実装内容
- DataGatewayにて保存したオブジェクトを全件削除メソッド（deleteAll()）を実装
- RankingManager経由でConfigViewControllerのcacheClearButtonアクションからdeleteAll()を呼ぶ