### PR TITLE
#13 保存されているFavoriteObjectを表示する

### DIFF
--- a/RakutenRanking/Base.lproj/Main.storyboard
+++ b/RakutenRanking/Base.lproj/Main.storyboard
@@ -82,7 +82,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="sKa-qB-9TA">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="84" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="sKa-qB-9TA">
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>

--- a/RakutenRanking/Base.lproj/Main.storyboard
+++ b/RakutenRanking/Base.lproj/Main.storyboard
@@ -86,19 +86,26 @@
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FavoriteListCell" id="Su5-1A-Yj4" customClass="FavoriteTableViewCell" customModule="RakutenRanking" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="FavoriteListCell" rowHeight="84" id="Su5-1A-Yj4" customClass="FavoriteTableViewCell" customModule="RakutenRanking" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="84"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Su5-1A-Yj4" id="Pa8-3r-zQh">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="83.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9eY-96-v76">
-                                                    <rect key="frame" x="15" y="-11" width="64" height="64"/>
+                                                    <rect key="frame" x="15" y="11" width="64" height="64"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X2a-iN-ulj">
-                                                    <rect key="frame" x="108" y="12" width="252" height="21"/>
+                                                    <rect key="frame" x="95" y="17" width="252" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iZ6-6p-3mQ">
+                                                    <rect key="frame" x="95" y="46" width="252" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -109,6 +116,7 @@
                                         <connections>
                                             <outlet property="itemImage" destination="9eY-96-v76" id="c2i-K0-mOC"/>
                                             <outlet property="itemName" destination="X2a-iN-ulj" id="JzL-sm-YIO"/>
+                                            <outlet property="itemPrice" destination="iZ6-6p-3mQ" id="TQk-0u-9ke"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
@@ -498,6 +506,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="40y-Rc-Ga9"/>
+        <segue reference="BtZ-ch-crA"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/RakutenRanking/DataGateway.swift
+++ b/RakutenRanking/DataGateway.swift
@@ -87,6 +87,7 @@ class DataGateway: DataGatewayProtocol {
             item.price = obj.price
             item.sSizeImageUrl = obj.sSizeImageUrl
             item.mSizeImageUrl = obj.mSizeImageUrl
+            item.itemCode = obj.itemCode
             itemArray.append(item)
         }
         callback(itemArray)

--- a/RakutenRanking/DataGateway.swift
+++ b/RakutenRanking/DataGateway.swift
@@ -76,4 +76,19 @@ class DataGateway: DataGatewayProtocol {
         }
     }
     
+    func getFavoriteItems(_ callback: @escaping ([Item]) -> Void) {
+        // お気に入りに保存しているitemを全件取得
+        let favoriteItems = realm.objects(FavoriteObject.self)
+        var itemArray = [Item]()
+        
+        favoriteItems.forEach { obj in
+            let item = Item()
+            item.name = obj.name
+            item.price = obj.price
+            item.sSizeImageUrl = obj.sSizeImageUrl
+            item.mSizeImageUrl = obj.mSizeImageUrl
+            itemArray.append(item)
+        }
+        callback(itemArray)
+    }
 }

--- a/RakutenRanking/DataGatewayProtocol.swift
+++ b/RakutenRanking/DataGatewayProtocol.swift
@@ -18,4 +18,6 @@ protocol DataGatewayProtocol {
     
     func saveFavoriteItem(item: Item)
     
+    func getFavoriteItems(_ callback: @escaping ([Item]) -> Void)
+    
 }

--- a/RakutenRanking/FavoriteTableViewCell.swift
+++ b/RakutenRanking/FavoriteTableViewCell.swift
@@ -11,8 +11,9 @@ import UIKit
 class FavoriteTableViewCell: UITableViewCell {
     
     @IBOutlet weak var itemName: UILabel!
+    @IBOutlet weak var itemPrice: UILabel!
     @IBOutlet weak var itemImage: UIImageView!
-
+    
     override func awakeFromNib() {
         super.awakeFromNib()
     }

--- a/RakutenRanking/FavoriteViewController.swift
+++ b/RakutenRanking/FavoriteViewController.swift
@@ -30,7 +30,6 @@ class FavoriteViewController: UIViewController, UITableViewDelegate, UITableView
         rankingManager.getFavoriteItem({[weak self](items: [Item]) -> Void in
             guard let `self` = self else { return }
             self.favoriteItem = items
-            print(self.favoriteItem)
         })
     }
     

--- a/RakutenRanking/FavoriteViewController.swift
+++ b/RakutenRanking/FavoriteViewController.swift
@@ -18,9 +18,21 @@ class FavoriteViewController: UIViewController, UITableViewDelegate, UITableView
         self.favoriteList.delegate = self
         self.favoriteList.dataSource = self
         self.navigationItem.title = "お気に入りリスト"
+        self.getFavoriteItem()
     }
     
+    private let rankingManager = RankingManager()
+    private var favoriteItem = [Item]()
+
     let favoriteItemList = ["お気に入り商品名１","お気に入り商品名２","お気に入り商品名３","お気に入り商品名４","お気に入り商品名５",]
+    
+    private func getFavoriteItem() {
+        rankingManager.getFavoriteItem({[weak self](items: [Item]) -> Void in
+            guard let `self` = self else { return }
+            self.favoriteItem = items
+            print(self.favoriteItem)
+        })
+    }
     
     // MARK: UITableViewDataSource
     

--- a/RakutenRanking/FavoriteViewController.swift
+++ b/RakutenRanking/FavoriteViewController.swift
@@ -17,6 +17,7 @@ class FavoriteViewController: UIViewController, UITableViewDelegate, UITableView
         
         self.favoriteList.delegate = self
         self.favoriteList.dataSource = self
+        self.navigationItem.title = "お気に入りリスト"
     }
     
     let favoriteItemList = ["お気に入り商品名１","お気に入り商品名２","お気に入り商品名３","お気に入り商品名４","お気に入り商品名５",]

--- a/RakutenRanking/FavoriteViewController.swift
+++ b/RakutenRanking/FavoriteViewController.swift
@@ -24,6 +24,7 @@ class FavoriteViewController: UIViewController, UITableViewDelegate, UITableView
     
     private let rankingManager = RankingManager()
     private var favoriteItem = [Item]()
+    var item: Item!
     
     private func getFavoriteItem() {
         rankingManager.getFavoriteItem({[weak self](items: [Item]) -> Void in
@@ -48,7 +49,7 @@ class FavoriteViewController: UIViewController, UITableViewDelegate, UITableView
     // セル内容
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier:"FavoriteListCell", for: indexPath) as! FavoriteTableViewCell
-        let item = self.favoriteItem[indexPath.row]
+        item = self.favoriteItem[indexPath.row]
         if let name: String = item.name {
             cell.itemName.text = "\(name)"
         }
@@ -63,7 +64,20 @@ class FavoriteViewController: UIViewController, UITableViewDelegate, UITableView
     
     // UITableViewDelegate
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // TODO タップ時のアクションを記述
+        // 商品詳細画面へ遷移
+        self.performSegue(withIdentifier: "toDetail", sender: nil)
+    }
+    
+    // タップしたcellの値を取得
+    func tableView(_ tableView: UITableView, didHighlightRowAt indexPath: IndexPath) {
+        item = self.favoriteItem[indexPath.row]
+    }
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "toDetail" {
+            let itemDetailViewController = segue.destination as! ItemDetailViewController
+            itemDetailViewController.sendItem = self.item
+        }
     }
     
     override func didReceiveMemoryWarning() {

--- a/RakutenRanking/FavoriteViewController.swift
+++ b/RakutenRanking/FavoriteViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import AFNetworking
 
 class FavoriteViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
@@ -23,8 +24,6 @@ class FavoriteViewController: UIViewController, UITableViewDelegate, UITableView
     
     private let rankingManager = RankingManager()
     private var favoriteItem = [Item]()
-
-    let favoriteItemList = ["お気に入り商品名１","お気に入り商品名２","お気に入り商品名３","お気に入り商品名４","お気に入り商品名５",]
     
     private func getFavoriteItem() {
         rankingManager.getFavoriteItem({[weak self](items: [Item]) -> Void in
@@ -43,14 +42,22 @@ class FavoriteViewController: UIViewController, UITableViewDelegate, UITableView
     
     // セル数
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.favoriteItemList.count
+        return self.favoriteItem.count
     }
     
     // セル内容
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier:"FavoriteListCell", for: indexPath) as! FavoriteTableViewCell
-        
-        cell.itemName.text = self.favoriteItemList[indexPath.row]
+        let item = self.favoriteItem[indexPath.row]
+        if let name: String = item.name {
+            cell.itemName.text = "\(name)"
+        }
+        if let price: String = item.price {
+            cell.itemPrice.text = "\(price)円"
+        }
+        if let image: String = item.sSizeImageUrl {
+            cell.itemImage.setImageWith(URL(string: image)!)
+        }
         return cell
     }
     

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -58,5 +58,11 @@ class RankingManager {
         dataGateway.saveFavoriteItem(item: item)
     }
     
+    func getFavoriteItem(_ callback: @escaping ([Item]) -> Void) {
+        dataGateway.getFavoriteItems({(items: [Item]) -> Void in
+            callback(items)
+        })
+    }
+    
 }
 


### PR DESCRIPTION
# issue
#13 

# 実装内容
* `FavoriteObject` の取得、 `[Item]` へ変換するメソッド( `getFavoriteItems()` )を実装
* `FavoriteViewController` から `getFavoriteItems()` を呼び出す
* お気に入り表示画面のタイトル編集
* `TableViewCell` の編集
* `cell` から画面遷移を行って商品詳細を表示する