### PR TITLE
#18 お気に入りリセットボタンの実装

### DIFF
--- a/RakutenRanking/ConfigViewController.swift
+++ b/RakutenRanking/ConfigViewController.swift
@@ -32,8 +32,8 @@ class ConfigViewController: UIViewController, UINavigationControllerDelegate {
     }
     
     @IBAction func favoResetBtn() {
-        // TODO お気に入り全削除処理を実装
-        print("お気に入りリセットボタン押された")
+        // お気に入り全削除処理を実装
+        rankingManager.deleteFavorite()
     }
     
     override func viewDidLoad() {

--- a/RakutenRanking/DataGateway.swift
+++ b/RakutenRanking/DataGateway.swift
@@ -92,4 +92,10 @@ class DataGateway: DataGatewayProtocol {
         }
         callback(itemArray)
     }
+    
+    func deleteFavoriteObject() {
+        try! realm.write {
+            realm.deleteAll()
+        }
+    }
 }

--- a/RakutenRanking/DataGatewayProtocol.swift
+++ b/RakutenRanking/DataGatewayProtocol.swift
@@ -20,4 +20,6 @@ protocol DataGatewayProtocol {
     
     func getFavoriteItems(_ callback: @escaping ([Item]) -> Void)
     
+    func deleteFavoriteObject()
+    
 }

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -64,5 +64,9 @@ class RankingManager {
         })
     }
     
+    func deleteFavorite() {
+        dataGateway.deleteDataObject()
+    }
+    
 }
 


### PR DESCRIPTION
# issue
#18 

# 実装内容
* `FavoriteObject` を一括削除するメソッド( `deleteFavoriteObject()` )を定義
* `ConfigViewController` のお気に入りリセットボタンのアクションから `deleteFavoriteObject()` を呼ぶ