### PR TITLE
#83 #19 pageControlのタップアクションと動的なタイトルの追加

### DIFF
--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -100,8 +100,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
     
     private func selectTitleByRankingType(_ gender: Gender, _ age: Age) -> String {
-        var genderType = ""
-        var ageType = ""
+        let genderType: String
+        let ageType: String
         // 性別が指定されている場合
         switch gender {
         case .male:
@@ -109,7 +109,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         case .female:
             genderType = "女性"
         default:
-            break
+            genderType = ""
         }
         // 年代が指定されている場合
         switch age {
@@ -124,7 +124,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         case .fiftiesOver:
             ageType = "50代以上"
         default:
-            break
+            ageType = ""
         }
         return ageType + genderType
     }

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -85,9 +85,6 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         self.collectionView.delegate = self
         self.collectionView.dataSource = self
         
-        // ランキングタイトルを表示
-        self.navigationItem.title = "Ranking"
-        
         // 設定されたランキング種別を取得
         let type = rankingManager.getRankingTypeAtStartup()
         self.gender = type.gender
@@ -98,6 +95,28 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         super.viewDidAppear(animated)
         
         getRankingItem(gender: gender, age: age)
+        // ランキングタイトルを表示
+        self.navigationItem.title = "\(selectTitleByRankingType(gender, age))総合ランキング"
+    }
+    
+    private func selectTitleByRankingType(_ gender: Gender, _ age: Age) -> String {
+        var genderType = ""
+        var ageType = ""
+        // 性別が指定されている場合
+        if gender == .male {
+            genderType = "男性"
+        }
+        if gender == .female {
+            genderType = "女性"
+        }
+        // 年代が指定されている場合
+        if age == .fiftiesOver {
+            ageType = "50代以上"
+        } else if age != .notKnown {
+            ageType = "\(age.rawValue)代"
+        }
+        
+        return ageType + genderType
     }
     
     // ランキングデータを取得し、配列に格納する

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -301,12 +301,19 @@ extension ViewController: UIScrollViewDelegate {
         pageControl.currentPage = 0
         // pageControlのスケールを小さくする
         pageControl.transform = CGAffineTransform(scaleX: 0.7, y: 0.7)
+        // pageControlがタップされた時のアクションを追加
+        pageControl.isUserInteractionEnabled = true
+        pageControl.addTarget(self, action: #selector(movePageByTapping(_:)), for: .touchUpInside)
         
         self.view.addSubview(pageControl)
     }
     
     @objc func saveToOrDeleteFromFavoritesOnPageView(_ sender: UIButton) {
         rankingManager.saveOrDeleteFavoriteObject(item: self.rankingItemList[pageControl.currentPage])
+    }
+    
+    @objc func movePageByTapping(_ sender: UIPageControl) {
+        scrollView.contentOffset.x = scrollView.frame.maxX * CGFloat(sender.currentPage)
     }
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -102,7 +102,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     private func selectTitleByRankingType(_ gender: Gender, _ age: Age) -> String {
         let genderType: String
         let ageType: String
-        // 性別が指定されている場合
+        // 性別による分類
         switch gender {
         case .male:
             genderType = "男性"
@@ -111,13 +111,13 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         default:
             genderType = ""
         }
-        // 年代が指定されている場合
+        // 年代による分類
         switch age {
         case .teens:
             ageType = "10代"
         case .twenties:
             ageType = "20代"
-        case .thities:
+        case .thirties:
             ageType = "30代"
         case .forties:
             ageType = "40代"

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -103,19 +103,29 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         var genderType = ""
         var ageType = ""
         // 性別が指定されている場合
-        if gender == .male {
+        switch gender {
+        case .male:
             genderType = "男性"
-        }
-        if gender == .female {
+        case .female:
             genderType = "女性"
+        default:
+            break
         }
         // 年代が指定されている場合
-        if age == .fiftiesOver {
+        switch age {
+        case .teens:
+            ageType = "10代"
+        case .twenties:
+            ageType = "20代"
+        case .thities:
+            ageType = "30代"
+        case .forties:
+            ageType = "40代"
+        case .fiftiesOver:
             ageType = "50代以上"
-        } else if age != .notKnown {
-            ageType = "\(age.rawValue)代"
+        default:
+            break
         }
-        
         return ageType + genderType
     }
     


### PR DESCRIPTION
# issue
#83 
#19 

# 実装内容
#83 
* ページ表示の際、pageControl をタップしてランキング移動を可能にする
（中央より左側／右側をタップでランキングを一つ移動）

#19 
* 表示するランキング種別により、メイン画面のタイトルを変更する