### PR TITLE
#92 ランキングの更新

### DIFF
--- a/RakutenRanking/ConfigViewController.swift
+++ b/RakutenRanking/ConfigViewController.swift
@@ -33,7 +33,7 @@ class ConfigViewController: UIViewController, UINavigationControllerDelegate {
     
     @IBAction func cacheClearBtn() {
         // キャッシュクリア処理を実装
-        rankingManager.deleteData()
+        rankingManager.deleteAllData()
     }
     
     @IBAction func favoResetBtn() {

--- a/RakutenRanking/DataGateway.swift
+++ b/RakutenRanking/DataGateway.swift
@@ -64,9 +64,10 @@ class DataGateway: DataGatewayProtocol {
     }
     
     func deleteAllDataObject() {
+        let obj: Results<DataObject> = realm.objects(DataObject.self)
         // キャッシュクリア
         try! realm.write{
-            realm.deleteAll()
+            realm.delete(obj)
         }
     }
     
@@ -130,8 +131,9 @@ class DataGateway: DataGatewayProtocol {
     }
     
     func deleteAllFavoriteObject() {
+        let obj: Results<FavoriteObject> = realm.objects(FavoriteObject.self)
         try! realm.write {
-            realm.deleteAll()
+            realm.delete(obj)
         }
     }
     

--- a/RakutenRanking/DataGateway.swift
+++ b/RakutenRanking/DataGateway.swift
@@ -54,7 +54,16 @@ class DataGateway: DataGatewayProtocol {
         callback(itemArray)
     }
     
-    func deleteDataObject() {
+    func deleteDataObject(gender: Gender, age: Age) {
+        // 指定されたgender,ageに当てはまるオブジェクトをrealmから取得
+        let rankingData = realm.objects(RankingObject.self).filter("genderType = %@ AND ageType = %@", gender.rawValue, age.rawValue)
+        // 取得したオブジェクトをrealmから削除
+        try! realm.write {
+            realm.delete(rankingData)
+        }
+    }
+    
+    func deleteAllDataObject() {
         // キャッシュクリア
         try! realm.write{
             realm.deleteAll()

--- a/RakutenRanking/DataGatewayProtocol.swift
+++ b/RakutenRanking/DataGatewayProtocol.swift
@@ -14,7 +14,9 @@ protocol DataGatewayProtocol {
     
     func getItems(gender: Gender, age: Age, _ callback: @escaping ([Item]) -> Void)
     
-    func deleteDataObject()
+    func deleteDataObject(gender: Gender, age: Age)
+    
+    func deleteAllDataObject()
     
     func saveOrDeleteFavoriteItem(item: Item)
     

--- a/RakutenRanking/FavoriteViewController.swift
+++ b/RakutenRanking/FavoriteViewController.swift
@@ -34,7 +34,6 @@ class FavoriteViewController: UIViewController, UITableViewDelegate, UITableView
         super.viewWillAppear(animated)
         
         self.getFavoriteItem()
-        print(sortPattern)
         sortItem(index: sortPattern)
     }
     

--- a/RakutenRanking/RankingGateway.swift
+++ b/RakutenRanking/RankingGateway.swift
@@ -23,7 +23,7 @@ class RankingGateway: RankingGatewayProtocol {
                         callback(array)
                     },
                     failure: {(operation, error) -> Void in
-                        // response取得失敗
+                        // TODO: response取得失敗時の処理
                     })
     }
     

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -50,8 +50,12 @@ class RankingManager {
         })
     }
     
-    func deleteData() {
-        dataGateway.deleteDataObject()
+    func deleteData(gender: Gender, age: Age) {
+        dataGateway.deleteDataObject(gender: gender, age: age)
+    }
+    
+    func deleteAllData() {
+        dataGateway.deleteAllDataObject()
     }
     
     func saveOrDeleteFavoriteObject(item: Item) {

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -137,6 +137,10 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         })
     }
     
+    private func refreshRanking(gender: Gender, age: Age) {
+        rankingManager.deleteData(gender: gender, age: age)
+    }
+    
      private func displayRanking(array: [Item]) {
         self.rankingItemList = array
         self.mainRanking.reloadData()

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -97,8 +97,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     @objc func refreshRanking(_ sender: UIRefreshControl) {
         rankingManager.deleteData(gender: gender, age: age)
-        self.getRankingItem(gender: gender, age: age)
-        sender.endRefreshing()
+        self.getRankingItem(gender: gender, age: age, sender)
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -140,10 +139,13 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
     
     // ランキングデータを取得し、配列に格納する
-    private func getRankingItem(gender: Gender, age: Age) {
+    private func getRankingItem(gender: Gender, age: Age, _ sender: UIRefreshControl? = nil) {
         rankingManager.getRanking(gender: gender, age: age, {[weak self](array: [Item]) -> Void in
             guard let `self` = self else { return }
             self.displayRanking(array: array)
+            if sender != nil {
+                sender!.endRefreshing()
+            }
         })
     }
     

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -36,7 +36,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     @IBAction func changeToGrid(_ sender: Any){
         self.mainRanking.isHidden = true
-        view.addSubview(collectionView)
+        self.showGridView()
         self.removePageView()
     }
     
@@ -89,6 +89,16 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         let type = rankingManager.getRankingTypeAtStartup()
         self.gender = type.gender
         self.age = type.age
+        
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(refreshRanking(_:)), for: .valueChanged)
+        mainRanking.refreshControl = refreshControl
+        }
+    
+    @objc func refreshRanking(_ sender: UIRefreshControl) {
+        rankingManager.deleteData(gender: gender, age: age)
+        self.getRankingItem(gender: gender, age: age)
+        sender.endRefreshing()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -135,10 +145,6 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             guard let `self` = self else { return }
             self.displayRanking(array: array)
         })
-    }
-    
-    private func refreshRanking(gender: Gender, age: Age) {
-        rankingManager.deleteData(gender: gender, age: age)
     }
     
      private func displayRanking(array: [Item]) {
@@ -255,6 +261,13 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
     // アイテム詳細画面へ渡す値をcellから取得
     func collectionView(_ collectionView: UICollectionView, didHighlightItemAt indexPath: IndexPath) {
         item = self.rankingItemList[indexPath.row]
+    }
+    
+    private func showGridView() {
+        view.addSubview(collectionView)
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(refreshRanking(_:)), for: .valueChanged)
+        collectionView.refreshControl = refreshControl
     }
 
 }

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -143,9 +143,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         rankingManager.getRanking(gender: gender, age: age, {[weak self](array: [Item]) -> Void in
             guard let `self` = self else { return }
             self.displayRanking(array: array)
-            if sender != nil {
-                sender!.endRefreshing()
-            }
+            sender?.endRefreshing()
         })
     }
     

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -93,7 +93,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(refreshRanking(_:)), for: .valueChanged)
         mainRanking.refreshControl = refreshControl
-        }
+    }
     
     @objc func refreshRanking(_ sender: UIRefreshControl) {
         rankingManager.deleteData(gender: gender, age: age)
@@ -149,7 +149,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         })
     }
     
-     private func displayRanking(array: [Item]) {
+    private func displayRanking(array: [Item]) {
         self.rankingItemList = array
         self.mainRanking.reloadData()
         self.collectionView.reloadData()


### PR DESCRIPTION
# issue
#92 

# 実装内容
* 表示中のランキングをデータから削除する
* 削除したランキング種別のデータを、再度通信処理を行い取得する
* 画面を下に引き下げた際に更新処理を実行
* リスト表示、グリッド表示で更新可能に
-----------
以下issueの内容とは別に修正
* DataGateway の deleteAllDataObject() の実装内容を修正
  -> キャッシュクリアの際にお気に入りリストもリセットされてしまっていたため、DataObject 型のデータのみ全件削除。
* DataGateway の deleteAllFavoriteObject() の実装内容を修正
   -> DataObject ごと全件削除していたため FavoriteObject 型のデータのみ全件削除。
* FavoriteViewController の不要な print 関数の削除