### PR TITLE
#10 メニュー画面（内容変更）

### DIFF
--- a/RakutenRanking/Base.lproj/Main.storyboard
+++ b/RakutenRanking/Base.lproj/Main.storyboard
@@ -173,9 +173,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="CZg-2f-0Zz">
-                                <rect key="frame" x="0.0" y="10" width="320" height="647"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="CZg-2f-0Zz">
+                                <rect key="frame" x="0.0" y="64" width="320" height="603"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MenuCell" id="lEX-MG-wkZ" customClass="MenuTableViewCell" customModule="RakutenRanking" customModuleProvider="target">
@@ -200,8 +199,24 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yFb-w1-hI2">
+                                <rect key="frame" x="0.0" y="20" width="320" height="44"/>
+                                <color key="tintColor" red="0.70196563005447388" green="0.70195221900939941" blue="0.70196133852005005" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <items>
+                                    <navigationItem title="menu" id="2aU-da-Tfe"/>
+                                </items>
+                            </navigationBar>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" red="0.97647720575332642" green="0.9764588475227356" blue="0.97647136449813843" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="CZg-2f-0Zz" firstAttribute="top" secondItem="yFb-w1-hI2" secondAttribute="bottom" id="3KN-nc-IYM"/>
+                            <constraint firstItem="CZg-2f-0Zz" firstAttribute="trailing" secondItem="Ur5-Us-vf0" secondAttribute="trailing" id="8gg-Oc-fND"/>
+                            <constraint firstItem="CZg-2f-0Zz" firstAttribute="leading" secondItem="Ur5-Us-vf0" secondAttribute="leading" id="Am9-Qz-xOC"/>
+                            <constraint firstItem="yFb-w1-hI2" firstAttribute="leading" secondItem="Ur5-Us-vf0" secondAttribute="leading" id="OHd-R8-Zd0"/>
+                            <constraint firstItem="Ur5-Us-vf0" firstAttribute="bottom" secondItem="CZg-2f-0Zz" secondAttribute="bottom" id="Xy0-NS-63t"/>
+                            <constraint firstItem="yFb-w1-hI2" firstAttribute="top" secondItem="Ur5-Us-vf0" secondAttribute="top" id="f8g-Ii-6Kv"/>
+                            <constraint firstItem="yFb-w1-hI2" firstAttribute="trailing" secondItem="Ur5-Us-vf0" secondAttribute="trailing" id="mgz-n9-Qxe"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="Ur5-Us-vf0"/>
                     </view>
                     <size key="freeformSize" width="320" height="667"/>
@@ -211,7 +226,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="I2f-sU-gbg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-408" y="1155"/>
+            <point key="canvasLocation" x="-408" y="1154.5727136431785"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">

--- a/RakutenRanking/Base.lproj/Main.storyboard
+++ b/RakutenRanking/Base.lproj/Main.storyboard
@@ -194,7 +194,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <outlet property="rankingType" destination="JW2-l2-vMc" id="f3q-9i-p1Z"/>
+                                            <outlet property="menuList" destination="JW2-l2-vMc" id="Ouo-42-P2v"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/RakutenRanking/Base.lproj/Main.storyboard
+++ b/RakutenRanking/Base.lproj/Main.storyboard
@@ -206,7 +206,7 @@
                     </view>
                     <size key="freeformSize" width="320" height="667"/>
                     <connections>
-                        <outlet property="menuRanking" destination="CZg-2f-0Zz" id="Ef7-ud-2mK"/>
+                        <outlet property="menuList" destination="CZg-2f-0Zz" id="8RN-UG-dNC"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="I2f-sU-gbg" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/RakutenRanking/Base.lproj/Main.storyboard
+++ b/RakutenRanking/Base.lproj/Main.storyboard
@@ -224,22 +224,6 @@
                             <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aux-V3-qh8">
                                 <rect key="frame" x="0.0" y="623" width="375" height="44"/>
                                 <items>
-                                    <barButtonItem title="List" id="ryj-6D-2LN">
-                                        <connections>
-                                            <action selector="changeToList:" destination="BYZ-38-t0r" id="FR4-Dl-54n"/>
-                                        </connections>
-                                    </barButtonItem>
-                                    <barButtonItem title="Grid" id="40d-b8-A67">
-                                        <connections>
-                                            <action selector="changeToGrid:" destination="BYZ-38-t0r" id="Myx-hy-sIf"/>
-                                        </connections>
-                                    </barButtonItem>
-                                    <barButtonItem title="Item" id="wtO-fR-94U">
-                                        <connections>
-                                            <action selector="changeToPage:" destination="BYZ-38-t0r" id="Ad4-7x-Ilc"/>
-                                        </connections>
-                                    </barButtonItem>
-                                    <barButtonItem style="plain" systemItem="flexibleSpace" id="KWr-Ac-qj1"/>
                                     <barButtonItem title="config" id="aAe-6z-Kbb">
                                         <connections>
                                             <action selector="showConfigView:" destination="BYZ-38-t0r" id="GOp-Xp-c5f"/>

--- a/RakutenRanking/Base.lproj/Main.storyboard
+++ b/RakutenRanking/Base.lproj/Main.storyboard
@@ -178,37 +178,24 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MenuRankingCell" id="lEX-MG-wkZ" customClass="MenuTableViewCell" customModule="RakutenRanking" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MenuCell" id="lEX-MG-wkZ" customClass="MenuTableViewCell" customModule="RakutenRanking" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lEX-MG-wkZ" id="ImJ-Mp-NqJ">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9k-5X-fQJ">
-                                                    <rect key="frame" x="15" y="0.0" width="42" height="44"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="22"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JW2-l2-vMc">
-                                                    <rect key="frame" x="137" y="11" width="221" height="21"/>
+                                                    <rect key="frame" x="21" y="11" width="221" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oHY-XU-Fh9">
-                                                    <rect key="frame" x="57" y="-11" width="64" height="64"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                </imageView>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <outlet property="itemImage" destination="oHY-XU-Fh9" id="6iB-Vv-ZRQ"/>
-                                            <outlet property="itemName" destination="JW2-l2-vMc" id="5Bb-lS-52y"/>
-                                            <outlet property="rank" destination="C9k-5X-fQJ" id="f36-gG-Gxy"/>
+                                            <outlet property="rankingType" destination="JW2-l2-vMc" id="f3q-9i-p1Z"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/RakutenRanking/Base.lproj/Main.storyboard
+++ b/RakutenRanking/Base.lproj/Main.storyboard
@@ -173,84 +173,53 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UbY-QK-UfQ">
-                                <rect key="frame" x="0.0" y="20" width="320" height="647"/>
-                                <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="viI-yU-ys7">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="647"/>
-                                        <subviews>
-                                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="CZg-2f-0Zz">
-                                                <rect key="frame" x="0.0" y="0.0" width="320" height="647"/>
-                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <prototypes>
-                                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MenuRankingCell" id="lEX-MG-wkZ" customClass="MenuTableViewCell" customModule="RakutenRanking" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="28" width="320" height="44"/>
-                                                        <autoresizingMask key="autoresizingMask"/>
-                                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lEX-MG-wkZ" id="ImJ-Mp-NqJ">
-                                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
-                                                            <autoresizingMask key="autoresizingMask"/>
-                                                            <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9k-5X-fQJ">
-                                                                    <rect key="frame" x="15" y="0.0" width="42" height="44"/>
-                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                                    <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="22"/>
-                                                                    <nil key="textColor"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JW2-l2-vMc">
-                                                                    <rect key="frame" x="137" y="11" width="221" height="21"/>
-                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                    <nil key="textColor"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oHY-XU-Fh9">
-                                                                    <rect key="frame" x="57" y="-11" width="64" height="64"/>
-                                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                                </imageView>
-                                                            </subviews>
-                                                        </tableViewCellContentView>
-                                                        <connections>
-                                                            <outlet property="itemImage" destination="oHY-XU-Fh9" id="6iB-Vv-ZRQ"/>
-                                                            <outlet property="itemName" destination="JW2-l2-vMc" id="5Bb-lS-52y"/>
-                                                            <outlet property="rank" destination="C9k-5X-fQJ" id="f36-gG-Gxy"/>
-                                                        </connections>
-                                                    </tableViewCell>
-                                                </prototypes>
-                                            </tableView>
-                                        </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="CZg-2f-0Zz" secondAttribute="trailing" id="2jA-rS-Ado"/>
-                                            <constraint firstItem="CZg-2f-0Zz" firstAttribute="leading" secondItem="viI-yU-ys7" secondAttribute="leading" id="4I1-u8-Crq"/>
-                                            <constraint firstAttribute="bottom" secondItem="CZg-2f-0Zz" secondAttribute="bottom" id="czX-cV-gBw"/>
-                                            <constraint firstItem="CZg-2f-0Zz" firstAttribute="top" secondItem="viI-yU-ys7" secondAttribute="top" id="djZ-tT-fOy"/>
-                                            <constraint firstAttribute="width" constant="320" id="plI-cf-u6u"/>
-                                        </constraints>
-                                    </view>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="viI-yU-ys7" secondAttribute="trailing" id="3JV-g2-nnv"/>
-                                    <constraint firstItem="viI-yU-ys7" firstAttribute="height" secondItem="UbY-QK-UfQ" secondAttribute="height" id="JP0-4M-a1r"/>
-                                    <constraint firstAttribute="bottom" secondItem="viI-yU-ys7" secondAttribute="bottom" id="Lxt-R2-QXd"/>
-                                    <constraint firstItem="viI-yU-ys7" firstAttribute="leading" secondItem="UbY-QK-UfQ" secondAttribute="leading" id="r34-Q3-6OL"/>
-                                    <constraint firstItem="viI-yU-ys7" firstAttribute="top" secondItem="UbY-QK-UfQ" secondAttribute="top" id="wlC-OA-Pzy"/>
-                                </constraints>
-                            </scrollView>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="CZg-2f-0Zz">
+                                <rect key="frame" x="0.0" y="10" width="320" height="647"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MenuRankingCell" id="lEX-MG-wkZ" customClass="MenuTableViewCell" customModule="RakutenRanking" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lEX-MG-wkZ" id="ImJ-Mp-NqJ">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C9k-5X-fQJ">
+                                                    <rect key="frame" x="15" y="0.0" width="42" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="22"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JW2-l2-vMc">
+                                                    <rect key="frame" x="137" y="11" width="221" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oHY-XU-Fh9">
+                                                    <rect key="frame" x="57" y="-11" width="64" height="64"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </imageView>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="itemImage" destination="oHY-XU-Fh9" id="6iB-Vv-ZRQ"/>
+                                            <outlet property="itemName" destination="JW2-l2-vMc" id="5Bb-lS-52y"/>
+                                            <outlet property="rank" destination="C9k-5X-fQJ" id="f36-gG-Gxy"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="UbY-QK-UfQ" firstAttribute="bottom" secondItem="Ur5-Us-vf0" secondAttribute="bottom" id="GZz-hV-zAB"/>
-                            <constraint firstItem="UbY-QK-UfQ" firstAttribute="top" secondItem="Ur5-Us-vf0" secondAttribute="top" id="KXj-FO-s9W"/>
-                            <constraint firstItem="UbY-QK-UfQ" firstAttribute="trailing" secondItem="Ur5-Us-vf0" secondAttribute="trailing" id="LNs-Jh-EXI"/>
-                            <constraint firstItem="UbY-QK-UfQ" firstAttribute="leading" secondItem="Ur5-Us-vf0" secondAttribute="leading" id="rkX-X3-Z6h"/>
-                        </constraints>
                         <viewLayoutGuide key="safeArea" id="Ur5-Us-vf0"/>
                     </view>
                     <size key="freeformSize" width="320" height="667"/>
                     <connections>
                         <outlet property="menuRanking" destination="CZg-2f-0Zz" id="Ef7-ud-2mK"/>
-                        <outlet property="scrollView" destination="UbY-QK-UfQ" id="RD9-fd-OOz"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="I2f-sU-gbg" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -541,6 +510,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="BtZ-ch-crA"/>
+        <segue reference="jvl-Fl-qlr"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/RakutenRanking/MenuTableViewCell.swift
+++ b/RakutenRanking/MenuTableViewCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class MenuTableViewCell: UITableViewCell {
     
-    @IBOutlet weak var rankingType: UILabel!
+    @IBOutlet weak var menuList: UILabel!
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/RakutenRanking/MenuTableViewCell.swift
+++ b/RakutenRanking/MenuTableViewCell.swift
@@ -10,9 +10,7 @@ import UIKit
 
 class MenuTableViewCell: UITableViewCell {
     
-    @IBOutlet weak var rank: UILabel!
-    @IBOutlet weak var itemName: UILabel!
-    @IBOutlet weak var itemImage: UIImageView!
+    @IBOutlet weak var rankingType: UILabel!
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -10,14 +10,7 @@ import UIKit
 
 class MenuViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
-    @IBOutlet weak var menuRanking: UITableView!
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        self.menuRanking.delegate = self
-        self.menuRanking.dataSource = self
-    }
+    @IBOutlet weak var menuList: UITableView!
     
     // テーブルのデータに使う配列
     private let genderType = ["男性", "女性"]
@@ -25,6 +18,13 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     private let displayType = ["リスト表示", "グリッド表示", "ページ表示"]
     // セクションに使う配列
     private let sections = ["性別 で絞り込む", "年齢 で絞り込む", "表示方法 を選ぶ"]
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.menuList.delegate = self
+        self.menuList.dataSource = self
+    }
     
     // MARK: UITableViewDataSource
     
@@ -38,21 +38,7 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         return sections[section]
     }
     
-    // cellが選択された時に呼ばれる
-    private func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: IndexPath) {
-        switch indexPath.section {
-        case 0:
-            print("Value: \(genderType[indexPath.row])")
-        case 1:
-            print("Value: \(ageType[indexPath.row])")
-        case 2:
-            print("Value: \(displayType[indexPath.row])")
-        default:
-            print("Value: nil")
-        }
-    }
-    
-    // セル数
+    // 各セクションのセル数
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
         case 0:
@@ -86,9 +72,21 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     // MARK: UITableViewDelegate
     
+    // cellが選択された時に呼ばれる
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        menuList.deselectRow(at: indexPath, animated: true)
         // TODO: ランキング種別の絞り込みを設定したら、表示するランキングを変更する
         // TODO: 表示設定の切り替えをしたら、表示方法を変更する
+        switch indexPath.section {
+        case 0:
+            print("Value: \(genderType[indexPath.row])")
+        case 1:
+            print("Value: \(ageType[indexPath.row])")
+        case 2:
+            print("Value: \(displayType[indexPath.row])")
+        default:
+            print("Value: nil")
+        }
     }
     
     override func didReceiveMemoryWarning() {

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -24,6 +24,9 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     static var age: Age = .notKnown
     // ランキング表示方法の変更を保持する
     static var displayPattern: Int = 0
+    // チェックマークの有無を保持する
+    var checkMarks = [false, false, false, false, false]
+    private var selectedCell: UITableViewCell!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -81,16 +84,49 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     // cellが選択された時に呼ばれる
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         menuList.deselectRow(at: indexPath, animated: true)
-        // タップされたセルを取得して変数に設定を保持する
-        switch indexPath.section {
-        case 0:
-            self.setGender(index: indexPath.row)
-        case 1:
-            self.setAge(index: indexPath.row)
-        case 2:
-            MenuViewController.displayPattern = indexPath.row
-        default:
-            break
+        selectedCell = tableView.cellForRow(at: indexPath)
+        
+        // タップされたセルにチェックマークをつけて変数に設定を保持する
+        changeRankingType(indexPath: indexPath)
+    }
+    
+    private func changeRankingType(indexPath: IndexPath) {
+        if selectedCell == menuList.cellForRow(at: indexPath) {
+            if selectedCell.accessoryType == .none {
+                selectedCell.accessoryType = .checkmark
+                // チェックマークをつけた動作をセクション毎に変更する
+                switch indexPath.section {
+                case 0:
+                    self.setGender(index: indexPath.row)
+                case 1:
+                    self.setAge(index: indexPath.row)
+                case 3:
+                    MenuViewController.displayPattern = indexPath.row
+                default:
+                    break
+                }
+                checkMarks = checkMarks.enumerated().flatMap { (elem: (Int, Bool)) -> Bool in
+                    if indexPath.row != elem.0 {
+                        let otherCellIndexPath = NSIndexPath(row: elem.0, section: indexPath.section)
+                        if let otherCell = menuList.cellForRow(at: otherCellIndexPath as IndexPath) {
+                            otherCell.accessoryType = .none
+                        }
+                    }
+                    return indexPath.row == elem.0
+                }
+            } else {
+                // チェックマークがついている行をタップした際の動作をセクション毎に変更する
+                switch indexPath.section {
+                case 0:
+                    selectedCell.accessoryType = .none
+                    MenuViewController.gender = .notKnown
+                case 1:
+                    selectedCell.accessoryType = .none
+                    MenuViewController.age = .notKnown
+                default:
+                    break
+                }
+            }
         }
     }
     

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -19,34 +19,76 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         self.menuRanking.dataSource = self
     }
     
-    // セル表示用のテストデータ
-    let rankingList = ["1位の商品名", "2位の商品名", "3位の商品名", "4位の商品名", "5位の商品名", "6位の商品名", "7位の商品名", "8位の商品名", "9位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名", "10位の商品名"]
+    // テーブルのデータに使う配列
+    private let genderType = ["男性", "女性"]
+    private let ageType = ["10代", "20代", "30代", "40代", "50代 以上"]
+    private let displayType = ["リスト表示", "グリッド表示", "ページ表示"]
+    // セクションに使う配列
+    private let sections = ["性別 で絞り込む", "年齢 で絞り込む", "表示方法 を選ぶ"]
     
     // MARK: UITableViewDataSource
     
     // セクション数
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        return self.sections.count
+    }
+    
+    // セクションのタイトル
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return sections[section]
+    }
+    
+    // cellが選択された時に呼ばれる
+    private func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: IndexPath) {
+        switch indexPath.section {
+        case 0:
+            print("Value: \(genderType[indexPath.row])")
+        case 1:
+            print("Value: \(ageType[indexPath.row])")
+        case 2:
+            print("Value: \(displayType[indexPath.row])")
+        default:
+            print("Value: nil")
+        }
     }
     
     // セル数
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return self.rankingList.count
+        switch section {
+        case 0:
+            return genderType.count
+        case 1:
+            return ageType.count
+        case 2:
+            return displayType.count
+        default:
+            return 0
+        }
     }
     
     // セル内容
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "MenuRankingCell", for: indexPath) as! MenuTableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: "MenuCell", for: indexPath) as! MenuTableViewCell
         
-        cell.rank.text = String(indexPath.row + 1)
-        cell.itemName.text = self.rankingList[indexPath.row]
+        switch indexPath.section {
+        case 0:
+            cell.rankingType.text = genderType[indexPath.row]
+        case 1:
+            cell.rankingType.text = ageType[indexPath.row]
+        case 2:
+            cell.rankingType.text = displayType[indexPath.row]
+        default:
+            cell.rankingType.text = ""
+        }
+        
         return cell
     }
     
     // MARK: UITableViewDelegate
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // TODO: 各商品の詳細ページに遷移させる
+        // TODO: ランキング種別の絞り込みを設定したら、表示するランキングを変更する
+        // TODO: 表示設定の切り替えをしたら、表示方法を変更する
     }
     
     override func didReceiveMemoryWarning() {

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -81,8 +81,7 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     // cellが選択された時に呼ばれる
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         menuList.deselectRow(at: indexPath, animated: true)
-        // TODO: ランキング種別の絞り込みを設定したら、表示するランキングを変更する
-        // TODO: 表示設定の切り替えをしたら、表示方法を変更する
+        // タップされたセルを取得して変数に設定を保持する
         switch indexPath.section {
         case 0:
             self.setGender(index: indexPath.row)

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -35,6 +35,12 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         self.menuList.dataSource = self
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // リスト表示の行に予めチェックを入れておく
+        checkedDisplayPattern()
+    }
+    
     // MARK: UITableViewDataSource
     
     // セクション数
@@ -155,6 +161,13 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
             MenuViewController.age = .fiftiesOver
         default:
             MenuViewController.age = .notKnown
+        }
+    }
+    
+    private func checkedDisplayPattern() {
+        let indexPath = NSIndexPath(row: 0, section: 2)
+        if let myCell = menuList.cellForRow(at: indexPath as IndexPath) {
+            myCell.accessoryType = .checkmark
         }
     }
     

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -165,7 +165,7 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
     
     private func checkedDisplayPattern() {
-        let indexPath = NSIndexPath(row: 0, section: 2)
+        let indexPath = NSIndexPath(row: MenuViewController.displayPattern, section: 2)
         if let myCell = menuList.cellForRow(at: indexPath as IndexPath) {
             myCell.accessoryType = .checkmark
         }

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -100,7 +100,7 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
                     self.setGender(index: indexPath.row)
                 case 1:
                     self.setAge(index: indexPath.row)
-                case 3:
+                case 2:
                     MenuViewController.displayPattern = indexPath.row
                 default:
                     break

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -20,8 +20,8 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     private let sections = ["性別 で絞り込む", "年齢 で絞り込む", "表示方法 を選ぶ"]
     
     // 選択されたランキング種別を保持する
-    private var gender: Gender = .notKnown
-    private var age: Age = .notKnown
+    static var gender: Gender = .notKnown
+    static var age: Age = .notKnown
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -96,28 +96,28 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     private func convertGender(index: Int) {
         switch index {
         case 0:
-            self.gender = .male
+            MenuViewController.gender = .male
         case 1:
-            self.gender = .female
+            MenuViewController.gender = .female
         default:
-            self.gender = .notKnown
+            MenuViewController.gender = .notKnown
         }
     }
     
     private func convertAge(index: Int) {
         switch index {
         case 0:
-            self.age = .teens
+            MenuViewController.age = .teens
         case 1:
-            self.age = .twenties
+            MenuViewController.age = .twenties
         case 2:
-            self.age = .thirties
+            MenuViewController.age = .thirties
         case 3:
-            self.age = .forties
+            MenuViewController.age = .forties
         case 4:
-            self.age = .fiftiesOver
+            MenuViewController.age = .fiftiesOver
         default:
-            self.age = .notKnown
+            MenuViewController.age = .notKnown
         }
     }
     

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -64,13 +64,13 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         
         switch indexPath.section {
         case 0:
-            cell.rankingType.text = genderType[indexPath.row]
+            cell.menuList.text = genderType[indexPath.row]
         case 1:
-            cell.rankingType.text = ageType[indexPath.row]
+            cell.menuList.text = ageType[indexPath.row]
         case 2:
-            cell.rankingType.text = displayType[indexPath.row]
+            cell.menuList.text = displayType[indexPath.row]
         default:
-            cell.rankingType.text = ""
+            cell.menuList.text = ""
         }
         
         return cell

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -22,6 +22,8 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     // 選択されたランキング種別を保持する
     static var gender: Gender = .notKnown
     static var age: Age = .notKnown
+    // ランキング表示方法の変更を保持する
+    static var displayPattern: Int = 0
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -87,9 +89,9 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         case 1:
             self.setAge(index: indexPath.row)
         case 2:
-            print("Value: \(displayType[indexPath.row])")
+            MenuViewController.displayPattern = indexPath.row
         default:
-            print("Value: nil")
+            break
         }
     }
     

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -8,41 +8,12 @@
 
 import UIKit
 
-class MenuViewController: UIViewController, UIScrollViewDelegate, UITableViewDelegate, UITableViewDataSource {
+class MenuViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
     @IBOutlet weak var menuRanking: UITableView!
-    @IBOutlet weak var scrollView: UIScrollView!
-    @IBOutlet weak var pageControl: UIPageControl!
-    
-    @IBAction func chooseAge(_ sender: UISegmentedControl) {
-        switch sender.selectedSegmentIndex {
-        case 0:
-            // TODO 総合を選択したときの処理
-            print("総合を選択")
-        case 1:
-            // TODO 10代を選択したときの処理
-            print("10代を選択")
-        case 2:
-            // TODO 20代を選択したときの処理
-            print("20代を選択")
-        case 3:
-            // TODO 30代を選択したときの処理
-            print("30代を選択")
-        case 4:
-            // TODO 40代を選択したときの処理
-            print("40代を選択")
-        case 5:
-            // TODO 50代~を選択したときの処理
-            print("50代以上を選択")
-        default:
-            print("デフォルトは総合")
-        }
-    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        scrollView.delegate = self
         
         self.menuRanking.delegate = self
         self.menuRanking.dataSource = self

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -83,9 +83,9 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         // TODO: 表示設定の切り替えをしたら、表示方法を変更する
         switch indexPath.section {
         case 0:
-            self.convertGender(index: indexPath.row)
+            self.setGender(index: indexPath.row)
         case 1:
-            self.convertAge(index: indexPath.row)
+            self.setAge(index: indexPath.row)
         case 2:
             print("Value: \(displayType[indexPath.row])")
         default:
@@ -93,7 +93,7 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
     }
     
-    private func convertGender(index: Int) {
+    private func setGender(index: Int) {
         switch index {
         case 0:
             MenuViewController.gender = .male
@@ -104,7 +104,7 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
     }
     
-    private func convertAge(index: Int) {
+    private func setAge(index: Int) {
         switch index {
         case 0:
             MenuViewController.age = .teens

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -19,6 +19,10 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     // セクションに使う配列
     private let sections = ["性別 で絞り込む", "年齢 で絞り込む", "表示方法 を選ぶ"]
     
+    // 選択されたランキング種別を保持する
+    private var gender: Gender = .notKnown
+    private var age: Age = .notKnown
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -79,13 +83,41 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         // TODO: 表示設定の切り替えをしたら、表示方法を変更する
         switch indexPath.section {
         case 0:
-            print("Value: \(genderType[indexPath.row])")
+            self.convertGender(index: indexPath.row)
         case 1:
-            print("Value: \(ageType[indexPath.row])")
+            self.convertAge(index: indexPath.row)
         case 2:
             print("Value: \(displayType[indexPath.row])")
         default:
             print("Value: nil")
+        }
+    }
+    
+    private func convertGender(index: Int) {
+        switch index {
+        case 0:
+            self.gender = .male
+        case 1:
+            self.gender = .female
+        default:
+            self.gender = .notKnown
+        }
+    }
+    
+    private func convertAge(index: Int) {
+        switch index {
+        case 0:
+            self.age = .teens
+        case 1:
+            self.age = .twenties
+        case 2:
+            self.age = .thirties
+        case 3:
+            self.age = .forties
+        case 4:
+            self.age = .fiftiesOver
+        default:
+            self.age = .notKnown
         }
     }
     

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -9,10 +9,11 @@
 import UIKit
 import AFNetworking
 import RealmSwift
+import SlideMenuControllerSwift
 
 let screenSize: CGSize = CGSize(width: UIScreen.main.bounds.size.width, height: UIScreen.main.bounds.size.height)
 
-class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, SlideMenuControllerDelegate {
     
     @IBOutlet weak var mainRanking: UITableView!
     
@@ -93,6 +94,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(refreshRanking(_:)), for: .valueChanged)
         mainRanking.refreshControl = refreshControl
+        
+        self.slideMenuController()?.delegate = self
     }
     
     @objc func refreshRanking(_ sender: UIRefreshControl) {
@@ -155,6 +158,10 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     private func showMenu() {
         self.slideMenuController()?.openLeft()
+    }
+    
+    func leftDidClose() {
+        print("メニューしまった")
     }
     
     // MARK: UITableViewDatasource

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -161,7 +161,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
     
     func leftDidClose() {
-        print("メニューしまった")
+        self.gender = MenuViewController.gender
+        self.age = MenuViewController.age
     }
     
     // MARK: UITableViewDatasource

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -80,19 +80,15 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         mainRanking.refreshControl = refreshControl
         
         self.slideMenuController()?.delegate = self
+        
+        getRankingItem(gender: gender, age: age)
+        // ランキングタイトルを表示
+        self.navigationItem.title = "\(selectTitleByRankingType(gender, age))総合ランキング"
     }
     
     @objc func refreshRanking(_ sender: UIRefreshControl) {
         rankingManager.deleteData(gender: gender, age: age)
         self.getRankingItem(gender: gender, age: age, sender)
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        getRankingItem(gender: gender, age: age)
-        // ランキングタイトルを表示
-        self.navigationItem.title = "\(selectTitleByRankingType(gender, age))総合ランキング"
     }
     
     private func selectTitleByRankingType(_ gender: Gender, _ age: Age) -> String {
@@ -155,6 +151,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             self.displayPattern = MenuViewController.displayPattern
             setRankingPattern()
         }
+        // ランキングタイトルを表示
+        self.navigationItem.title = "\(selectTitleByRankingType(gender, age))総合ランキング"
     }
     
     private func setRankingPattern() {

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -73,6 +73,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     // ランキング種別を選択するための値
     var gender: Gender = Gender.notKnown
     var age: Age = Age.notKnown
+    // 表示方法のタイプを数値で保持
+    private var displayPattern: Int = 0
     
     // RankingManagerのインスタンス作成
     private let rankingManager = RankingManager()
@@ -161,10 +163,36 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
     
     func leftDidClose() {
-        if self.gender != MenuViewController.gender && self.age != MenuViewController.age {
+        if self.gender != MenuViewController.gender || self.age != MenuViewController.age {
             self.gender = MenuViewController.gender
             self.age = MenuViewController.age
             getRankingItem(gender: gender, age: age)
+        }
+        
+        if self.displayPattern != MenuViewController.displayPattern {
+            self.displayPattern = MenuViewController.displayPattern
+            setRankingPattern()
+        }
+    }
+    
+    private func setRankingPattern() {
+        switch displayPattern {
+        case 0:
+            self.mainRanking.isHidden = false
+            self.collectionView.removeFromSuperview()
+            self.removePageView()
+        case 1:
+            self.mainRanking.isHidden = true
+            self.showGridView()
+            self.removePageView()
+        case 2:
+            self.mainRanking.isHidden = true
+            self.collectionView.removeFromSuperview()
+            self.showPageView()
+        default:
+            self.mainRanking.isHidden = false
+            self.collectionView.removeFromSuperview()
+            self.removePageView()
         }
     }
     

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -161,8 +161,11 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
     
     func leftDidClose() {
-        self.gender = MenuViewController.gender
-        self.age = MenuViewController.age
+        if self.gender != MenuViewController.gender && self.age != MenuViewController.age {
+            self.gender = MenuViewController.gender
+            self.age = MenuViewController.age
+            getRankingItem(gender: gender, age: age)
+        }
     }
     
     // MARK: UITableViewDatasource

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -29,24 +29,6 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         self.performSegue(withIdentifier: "toFavoriteList", sender: nil)
     }
     
-    @IBAction func changeToList(_ sender: Any){
-        self.mainRanking.isHidden = false
-        self.collectionView.removeFromSuperview()
-        self.removePageView()
-    }
-    
-    @IBAction func changeToGrid(_ sender: Any){
-        self.mainRanking.isHidden = true
-        self.showGridView()
-        self.removePageView()
-    }
-    
-    @IBAction func changeToPage(_ sender: Any){
-        self.mainRanking.isHidden = true
-        self.collectionView.removeFromSuperview()
-        self.showPageView()
-    }
-    
     private let collectionView: UICollectionView = {
         //セルのレイアウト設計
         let layout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
@@ -178,22 +160,32 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     private func setRankingPattern() {
         switch displayPattern {
         case 0:
-            self.mainRanking.isHidden = false
-            self.collectionView.removeFromSuperview()
-            self.removePageView()
+            displayListView()
         case 1:
-            self.mainRanking.isHidden = true
-            self.showGridView()
-            self.removePageView()
+            displayGridView()
         case 2:
-            self.mainRanking.isHidden = true
-            self.collectionView.removeFromSuperview()
-            self.showPageView()
+            displayPageView()
         default:
-            self.mainRanking.isHidden = false
-            self.collectionView.removeFromSuperview()
-            self.removePageView()
+            displayListView()
         }
+    }
+    
+    private func displayListView() {
+        self.mainRanking.isHidden = false
+        self.collectionView.removeFromSuperview()
+        self.removePageView()
+    }
+    
+    private func displayGridView() {
+        self.mainRanking.isHidden = true
+        self.showGridView()
+        self.removePageView()
+    }
+    
+    private func displayPageView() {
+        self.mainRanking.isHidden = true
+        self.collectionView.removeFromSuperview()
+        self.showPageView()
     }
     
     // MARK: UITableViewDatasource


### PR DESCRIPTION
# issue 
#10 

# 実装内容
* ページ数変更
* `MenuTableViewCell` の変数名の修正
* セクションを３つに分割
  * ランキングを絞り込む（性別／年代）
  * 表示方法を変更する
* メニューを閉じたタイミングでランキングを変更
  * 選択したランキングの情報を`ViewController` で取得
  * （変更があれば）表示するランキングとタイトルを更新
* チェックボックスの実装
  * ランキングの絞り込み -> 単一選択、チェックが付いているところを押すと解除（総合を表示）。
  * 表示方法の変更 -> 単一選択、初期状態でリスト表示にチェックマークをつける。
    

* 機能面と簡単なviewの調整のみの実装です。細かいデザインは今週以降実装していきます。