### PR TITLE
#78 メイン画面（グリッド表示のviewの調整）

### DIFF
--- a/RakutenRanking/CollectionViewCell.swift
+++ b/RakutenRanking/CollectionViewCell.swift
@@ -24,8 +24,9 @@ class CollectionViewCell: UICollectionViewCell {
     // 値段のlabelを生成
     let itemPrice: UILabel = {
         let label = UILabel()
-        label.frame = CGRect(x: 0, y: 85, width: screenSize.width / 3.0, height: screenSize.width / 3.0)
-        label.textColor = UIColor.gray
+        label.frame = CGRect(x: 0, y: 95, width: screenSize.width / 3.0 - 5, height: screenSize.width / 3.0)
+        label.textColor = UIColor.darkGray
+        label.font = UIFont.systemFont(ofSize: 14, weight: .thin)
         label.textAlignment = .right
         return label
     }()

--- a/RakutenRanking/CollectionViewCell.swift
+++ b/RakutenRanking/CollectionViewCell.swift
@@ -13,8 +13,10 @@ class CollectionViewCell: UICollectionViewCell {
     // 商品名のlabelを生成
     let itemName: UILabel = {
         let label = UILabel()
-        label.frame = CGRect(x: 0, y: 65, width: screenSize.width / 3.0, height: screenSize.width / 3.0)
-        label.textColor = UIColor.gray
+        label.frame = CGRect(x: 5, y: 65, width: screenSize.width / 3.0 - 10, height: screenSize.width / 3.0)
+        label.textColor = UIColor.black
+        label.font = UIFont.systemFont(ofSize: 12, weight: .thin)
+        label.numberOfLines = 2
         label.textAlignment = .left
         return label
     }()

--- a/RakutenRanking/CollectionViewCell.swift
+++ b/RakutenRanking/CollectionViewCell.swift
@@ -49,10 +49,8 @@ class CollectionViewCell: UICollectionViewCell {
     // お気に入り登録ボタンを生成
     let favoriteButton: UIButton = {
         let button = UIButton()
-        button.frame = CGRect(x: 70, y: 160, width: 50, height: 25)
-        button.setTitleColor(UIColor.blue, for: .normal)
-        button.setTitle("Favo", for: UIControlState.normal)
-        button.titleLabel?.font =  UIFont.systemFont(ofSize: 16)
+        button.frame = CGRect(x: 90, y: 155, width: 40, height: 40)
+        button.setImage(UIImage(named: "NotFavorite"), for: .normal)
         button.addTarget(self, action: #selector(ViewController.saveToOrDeleteFromFavoritesOnGridView(_:)), for: .touchUpInside)
         return button
     }()
@@ -75,6 +73,12 @@ class CollectionViewCell: UICollectionViewCell {
     
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    // セル再利用時に初期化する
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        favoriteButton.setImage(UIImage(named: "NotFavorite"), for: .normal)
     }
     
 }

--- a/RakutenRanking/CollectionViewCell.swift
+++ b/RakutenRanking/CollectionViewCell.swift
@@ -42,7 +42,8 @@ class CollectionViewCell: UICollectionViewCell {
     
     // 商品画像を生成
     let itemImage: UIImageView = {
-        let image = UIImageView(frame: CGRect(x: 12, y: 10, width: 100, height: 100))
+        let image = UIImageView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        image.center = CGPoint(x: (screenSize.width / 3.0) / 2.0, y: (screenSize.height / 3.0) / 4.0)
         return image
     }()
     

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -93,6 +93,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.mainRanking.reloadData()
+        self.collectionView.reloadData()
     }
     
     @objc func refreshRanking(_ sender: UIRefreshControl) {
@@ -289,6 +290,10 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "CollectionViewCell", for: indexPath) as! CollectionViewCell
         item = self.rankingItemList[indexPath.row]
+        // セル生成時にお気に入り登録している商品はボタンの画像を変更
+        if self.rankingManager.isFavorite(item: item) {
+            cell.favoriteButton.setImage(UIImage(named: "Favorite"), for: .normal)
+        }
         cell.itemRank.text = " \(indexPath.row + 1)位"
         // nilチェックしてからcellに代入
         if let name: String = item.name {
@@ -308,7 +313,14 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
         let btn = sender as! UIButton
         let cell = btn.superview?.superview as! CollectionViewCell
         let row = collectionView.indexPath(for: cell)?.row
-        rankingManager.saveOrDeleteFavoriteObject(item: self.rankingItemList[row!])
+        let item = self.rankingItemList[row!]
+        rankingManager.saveOrDeleteFavoriteObject(item: item)
+        // お気に入り登録されているかどうかを判定して、ボタンに表示する画像を変更
+        if self.rankingManager.isFavorite(item: item) {
+            cell.favoriteButton.setImage(UIImage(named: "Favorite"), for: .normal)
+        } else {
+            cell.favoriteButton.setImage(UIImage(named: "NotFavorite"), for: .normal)
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -292,7 +292,7 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
         cell.itemRank.text = " \(indexPath.row + 1)位"
         // nilチェックしてからcellに代入
         if let name: String = item.name {
-            cell.itemName.text = " \(name)"
+            cell.itemName.text = "\(name)"
         }
         if let price: String = item.price {
             cell.itemPrice.text = "\(price)円"

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -41,7 +41,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         let collectionView = UICollectionView( frame: CGRect(x: 0, y: 0, width: screenSize.width, height: screenSize.height - 44 ), collectionViewLayout: layout)
         collectionView.backgroundColor = UIColor.white
         //セルの登録
-        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: "CollectionViewCell")
+        collectionView.register(CollectionViewCell.self, forCellWithReuseIdentifier: "CollectionViewCell")
         return collectionView
     }()
     

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -295,7 +295,7 @@ extension ViewController: UICollectionViewDataSource, UICollectionViewDelegateFl
             cell.itemName.text = "\(name)"
         }
         if let price: String = item.price {
-            cell.itemPrice.text = "\(price)円"
+            cell.itemPrice.text = "¥ \(self.convertPrice(price: price))"
         }
         if let image: String = item.mSizeImageUrl {
             // 画像の非同期取得


### PR DESCRIPTION
# issue
#78 

# 変更内容
* グリッド表示させようとすると落ちるバグの対応
* 商品名ラベルの調整
* 値段ラベルの調整
* 商品画像の調整（座標のみ）
* トグルボタンの実装
  * グリッド表示の際にお気に入り情報によって画像を変更
  * お気に入り追加登録 / 登録解除に合わせて画像を変更
  * セル再利用時に初期化
　　
* 順位ラベルは #39 で調整します。