### PR TITLE
#79 #80 メイン画面（ページ表示でのviewの調整）

### DIFF
--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -404,9 +404,7 @@ extension ViewController: UIScrollViewDelegate {
             }
             // お気に入り登録ボタン生成
             let favoriteButton: UIButton = UIButton()
-            favoriteButton.frame = CGRect(x: CGFloat(i) * width + width/2 - 150, y: height/1.4, width: 270, height: 40)
-            favoriteButton.contentHorizontalAlignment = .right
-            favoriteButton.backgroundColor = .gray
+            favoriteButton.frame = CGRect(x: CGFloat(i) * width + width/2 + 50, y: height/1.5 + 10, width: 70, height: 70)
             favoriteButton.setImage(UIImage(named: "NotFavorite"), for: .normal)
             favoriteButton.addTarget(self, action: #selector(saveToOrDeleteFromFavoritesOnPageView(_:)), for: .touchUpInside)
             

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -394,7 +394,7 @@ extension ViewController: UIScrollViewDelegate {
             itemPrice.frame = CGRect(x: CGFloat(i) * width + width/2 - 150, y: height/1.5, width: 300, height: 40)
             itemPrice.textAlignment = .center
             if let price: String = item.price {
-                itemPrice.text = "\(price)円"
+                itemPrice.text = "¥ \(self.convertPrice(price: price))"
             }
             // 商品画像を表示するimageView生成
             let itemImage: UIImageView = UIImageView()

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -384,6 +384,8 @@ extension ViewController: UIScrollViewDelegate {
             let itemName: UILabel = UILabel()
             itemName.frame = CGRect(x: CGFloat(i) * width + width/2 - 150, y: height/2 + 50, width: 300, height: 80)
             itemName.textAlignment = .center
+            itemName.numberOfLines = 2
+            itemName.font = UIFont.systemFont(ofSize: 16, weight: .thin)
             if let name: String = item.name {
                 itemName.text = "\(name)"
             }

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -366,6 +366,7 @@ extension ViewController: UIScrollViewDelegate {
         scrollView = UIScrollView()
         scrollView.frame = CGRect(x: 0, y: 0, width: width, height: height - 44 )
         scrollView.isPagingEnabled = true
+        scrollView.showsHorizontalScrollIndicator = false
         scrollView.delegate = self
         // scrollView全体のサイズ
         scrollView.contentSize = CGSize(width: CGFloat(page) * width, height: height - 44)

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -94,6 +94,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         super.viewWillAppear(animated)
         self.mainRanking.reloadData()
         self.collectionView.reloadData()
+        self.removePageView()
+        self.showPageView()
     }
     
     @objc func refreshRanking(_ sender: UIRefreshControl) {
@@ -180,19 +182,22 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     private func displayListView() {
         self.mainRanking.isHidden = false
-        self.collectionView.removeFromSuperview()
+        self.collectionView.isHidden = true
         self.removePageView()
     }
     
     private func displayGridView() {
         self.mainRanking.isHidden = true
-        self.showGridView()
+        if self.collectionView.isDescendant(of: view) == false {
+            self.showGridView()
+        }
+        self.collectionView.isHidden = false
         self.removePageView()
     }
     
     private func displayPageView() {
         self.mainRanking.isHidden = true
-        self.collectionView.removeFromSuperview()
+        self.collectionView.isHidden = true
         self.showPageView()
     }
     
@@ -406,8 +411,12 @@ extension ViewController: UIScrollViewDelegate {
             // お気に入り登録ボタン生成
             let favoriteButton: UIButton = UIButton()
             favoriteButton.frame = CGRect(x: CGFloat(i) * width + width/2 + 50, y: height/1.5 + 10, width: 70, height: 70)
-            favoriteButton.setImage(UIImage(named: "NotFavorite"), for: .normal)
             favoriteButton.addTarget(self, action: #selector(saveToOrDeleteFromFavoritesOnPageView(_:)), for: .touchUpInside)
+            favoriteButton.setImage(UIImage(named: "NotFavorite"), for: .normal)
+            if self.rankingManager.isFavorite(item: item) {
+                favoriteButton.setImage(UIImage(named: "Favorite"), for: .normal)
+            }
+            
             
             scrollView.addSubview(itemName)
             scrollView.addSubview(itemPrice)
@@ -472,8 +481,10 @@ extension ViewController: UIScrollViewDelegate {
     }
     
     private func showPageView() {
-        if self.scrollView == nil {
-            self.setPageView()
+        if mainRanking.isHidden == true && collectionView.isHidden == true {
+            if self.scrollView == nil {
+                self.setPageView()
+            }
         }
     }
     

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -419,8 +419,11 @@ extension ViewController: UIScrollViewDelegate {
         pageControl = UIPageControl()
         // pageControlの位置とサイズの設定
         pageControl.frame = CGRect(x: -50, y: height - 90, width: width + 100, height: 50)
-        // 背景色の設定
-        pageControl.backgroundColor = UIColor.darkGray
+        // インジケータの色
+        let rgba = UIColor(red: 0.8, green: 0.8, blue: 0.8, alpha: 0.8)
+        pageControl.pageIndicatorTintColor = rgba
+        // 現在ページのインジケータの色
+        pageControl.currentPageIndicatorTintColor = .gray
         // ページ数の設定
         pageControl.numberOfPages = page
         // 現在ページの設定

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -406,9 +406,8 @@ extension ViewController: UIScrollViewDelegate {
             let favoriteButton: UIButton = UIButton()
             favoriteButton.frame = CGRect(x: CGFloat(i) * width + width/2 - 150, y: height/1.4, width: 270, height: 40)
             favoriteButton.contentHorizontalAlignment = .right
-            favoriteButton.setTitleColor(UIColor.blue, for: .normal)
-            favoriteButton.setTitle("Favo", for: UIControlState.normal)
-            favoriteButton.titleLabel?.font =  UIFont.systemFont(ofSize: 16)
+            favoriteButton.backgroundColor = .gray
+            favoriteButton.setImage(UIImage(named: "NotFavorite"), for: .normal)
             favoriteButton.addTarget(self, action: #selector(saveToOrDeleteFromFavoritesOnPageView(_:)), for: .touchUpInside)
             
             scrollView.addSubview(itemName)
@@ -438,7 +437,14 @@ extension ViewController: UIScrollViewDelegate {
     }
     
     @objc func saveToOrDeleteFromFavoritesOnPageView(_ sender: UIButton) {
-        rankingManager.saveOrDeleteFavoriteObject(item: self.rankingItemList[pageControl.currentPage])
+        let item = self.rankingItemList[pageControl.currentPage]
+        rankingManager.saveOrDeleteFavoriteObject(item: item)
+        
+        if self.rankingManager.isFavorite(item: item) {
+            sender.setImage(UIImage(named: "Favorite"), for: .normal)
+        } else {
+            sender.setImage(UIImage(named: "NotFavorite"), for: .normal)
+        }
     }
     
     @objc func movePageByTapping(_ sender: UIPageControl) {


### PR DESCRIPTION
# issue
#79 
#80 

# 変更内容
* 商品名ラベル調整
* 値段ラベル調整
* pageControl の色を変更
* スクロールバーを非表示に設定
* トグルの実装
  * タップイベントでお気に入り情報を確認、画像を変える
  * タップイベントを感知する範囲の調整
  * ページ表示の際、お気に入り情報を反映してお気に入りボタンの画像を変更する
    * `viewWillAppear()` で `pageView` を削除 / 生成（更新）
    * `pageView` 生成時の判定のため、 `scrollView` の 表示 / 非表示 の切り替えを
 `.isHidden == true / false` で切り替えるように変更
　　
# 次回以降対応すること
* 現時点で、ページ表示からメニューを開いてランキング種別を切り替えても
メニューを閉じた段階では更新されないのですが、別 issue を作成してそちらで対応します。

* 値段ラベルは #39 で対応します。