### PR TITLE
バグの対応

### DIFF
--- a/RakutenRanking.xcodeproj/project.pbxproj
+++ b/RakutenRanking.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		59F66C7920638B4900A86F41 /* MenuTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F66C7820638B4900A86F41 /* MenuTableViewCell.swift */; };
 		59F66C7B20639F5500A86F41 /* FavoriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F66C7A20639F5500A86F41 /* FavoriteViewController.swift */; };
 		59F66C7D2063A47D00A86F41 /* FavoriteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F66C7C2063A47D00A86F41 /* FavoriteTableViewCell.swift */; };
+		59FE0AF420BFA041006672F8 /* Gender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FE0AF320BFA041006672F8 /* Gender.swift */; };
 		8DF89DC683602D09790FB8C2 /* Pods_RakutenRanking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A67EA6E6CB9B16842D66EF3 /* Pods_RakutenRanking.framework */; };
 /* End PBXBuildFile section */
 
@@ -85,6 +86,7 @@
 		59F66C7820638B4900A86F41 /* MenuTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTableViewCell.swift; sourceTree = "<group>"; };
 		59F66C7A20639F5500A86F41 /* FavoriteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteViewController.swift; sourceTree = "<group>"; };
 		59F66C7C2063A47D00A86F41 /* FavoriteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteTableViewCell.swift; sourceTree = "<group>"; };
+		59FE0AF320BFA041006672F8 /* Gender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gender.swift; sourceTree = "<group>"; };
 		6D72478A18FF06AC27D0D175 /* Pods-RakutenRanking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RakutenRanking.release.xcconfig"; path = "Pods/Target Support Files/Pods-RakutenRanking/Pods-RakutenRanking.release.xcconfig"; sourceTree = "<group>"; };
 		72998DECDA49A14BB7FAD41E /* Pods-RakutenRankingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RakutenRankingTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RakutenRankingTests/Pods-RakutenRankingTests.release.xcconfig"; sourceTree = "<group>"; };
 		E3AE5A68245543CFA08C1639 /* Pods-RakutenRanking.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RakutenRanking.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RakutenRanking/Pods-RakutenRanking.debug.xcconfig"; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 				59C5D7922088602600A28DCD /* DataGateway.swift */,
 				598E08E92088655400E5938D /* DataGatewayProtocol.swift */,
 				593A321D20BCFD8C0048CB46 /* NumberEditor.swift */,
+				59FE0AF320BFA041006672F8 /* Gender.swift */,
 			);
 			path = RakutenRanking;
 			sourceTree = "<group>";
@@ -378,6 +381,7 @@
 				59B937B8206B4ECA0076D56D /* RankingManager.swift in Sources */,
 				59E646FD20561A7700EFD54C /* ViewController.swift in Sources */,
 				5969F2E2208EC18800468D03 /* FavoriteObject.swift in Sources */,
+				59FE0AF420BFA041006672F8 /* Gender.swift in Sources */,
 				59F66C7720636ABE00A86F41 /* MenuViewController.swift in Sources */,
 				59F2E42320A3E21E00B309C1 /* SlideViewController.swift in Sources */,
 				59F66C7920638B4900A86F41 /* MenuTableViewCell.swift in Sources */,

--- a/RakutenRanking.xcodeproj/project.pbxproj
+++ b/RakutenRanking.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		59F66C7B20639F5500A86F41 /* FavoriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F66C7A20639F5500A86F41 /* FavoriteViewController.swift */; };
 		59F66C7D2063A47D00A86F41 /* FavoriteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59F66C7C2063A47D00A86F41 /* FavoriteTableViewCell.swift */; };
 		59FE0AF420BFA041006672F8 /* Gender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FE0AF320BFA041006672F8 /* Gender.swift */; };
+		59FE0AF620BFC2BE006672F8 /* Age.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FE0AF520BFC2BE006672F8 /* Age.swift */; };
 		8DF89DC683602D09790FB8C2 /* Pods_RakutenRanking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A67EA6E6CB9B16842D66EF3 /* Pods_RakutenRanking.framework */; };
 /* End PBXBuildFile section */
 
@@ -87,6 +88,7 @@
 		59F66C7A20639F5500A86F41 /* FavoriteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteViewController.swift; sourceTree = "<group>"; };
 		59F66C7C2063A47D00A86F41 /* FavoriteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteTableViewCell.swift; sourceTree = "<group>"; };
 		59FE0AF320BFA041006672F8 /* Gender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gender.swift; sourceTree = "<group>"; };
+		59FE0AF520BFC2BE006672F8 /* Age.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Age.swift; sourceTree = "<group>"; };
 		6D72478A18FF06AC27D0D175 /* Pods-RakutenRanking.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RakutenRanking.release.xcconfig"; path = "Pods/Target Support Files/Pods-RakutenRanking/Pods-RakutenRanking.release.xcconfig"; sourceTree = "<group>"; };
 		72998DECDA49A14BB7FAD41E /* Pods-RakutenRankingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RakutenRankingTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-RakutenRankingTests/Pods-RakutenRankingTests.release.xcconfig"; sourceTree = "<group>"; };
 		E3AE5A68245543CFA08C1639 /* Pods-RakutenRanking.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RakutenRanking.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RakutenRanking/Pods-RakutenRanking.debug.xcconfig"; sourceTree = "<group>"; };
@@ -173,6 +175,7 @@
 				598E08E92088655400E5938D /* DataGatewayProtocol.swift */,
 				593A321D20BCFD8C0048CB46 /* NumberEditor.swift */,
 				59FE0AF320BFA041006672F8 /* Gender.swift */,
+				59FE0AF520BFC2BE006672F8 /* Age.swift */,
 			);
 			path = RakutenRanking;
 			sourceTree = "<group>";
@@ -373,6 +376,7 @@
 				59B937B4206B4DDF0076D56D /* JsonConverter.swift in Sources */,
 				59B937B2206B4C8C0076D56D /* RankingGatewayProtocol.swift in Sources */,
 				598E08EA2088655400E5938D /* DataGatewayProtocol.swift in Sources */,
+				59FE0AF620BFC2BE006672F8 /* Age.swift in Sources */,
 				59761EA42064EBCA0067964D /* CollectionViewCell.swift in Sources */,
 				59F66C7B20639F5500A86F41 /* FavoriteViewController.swift in Sources */,
 				59BCB5822086D44700C56651 /* DataObject.swift in Sources */,

--- a/RakutenRanking/Age.swift
+++ b/RakutenRanking/Age.swift
@@ -1,0 +1,87 @@
+//
+//  Age.swift
+//  RakutenRanking
+//
+//  Created by mao takagai on 2018/05/31.
+//  Copyright © 2018年 mao takagai. All rights reserved.
+//
+
+import Foundation
+
+enum Age: Int {
+    
+    case notKnown = 0
+    case teens = 10
+    case twenties = 20
+    case thirties = 30
+    case forties = 40
+    case fiftiesOver = 50
+    
+    static func convertAgeToInt(age: Age) -> Int? {
+        switch age {
+        case .teens:
+            return 0
+        case .twenties:
+            return 1
+        case .thirties:
+            return 2
+        case .forties:
+            return 3
+        case .fiftiesOver:
+            return 4
+        default:
+            return nil
+        }
+    }
+    
+    static func convertAgeToString(age: Age) -> String {
+        switch age {
+        case .teens:
+            return "10代"
+        case .twenties:
+            return "20代"
+        case .thirties:
+            return "30代"
+        case .forties:
+            return "40代"
+        case .fiftiesOver:
+            return "50代以上"
+        default:
+            return ""
+        }
+    }
+    
+    static func setAgeByIndex(index: Int) -> Age {
+        switch index {
+        case 0:
+            return .teens
+        case 1:
+            return .twenties
+        case 2:
+            return .thirties
+        case 3:
+            return .forties
+        case 4:
+            return .fiftiesOver
+        default:
+            return .notKnown
+        }
+    }
+    
+    static func getAgeBySelectedNum(num: Int) -> Age {
+        switch num {
+        case 1:
+            return .teens
+        case 2:
+            return .twenties
+        case 3:
+            return .thirties
+        case 4:
+            return .forties
+        case 5:
+            return .fiftiesOver
+        default:
+            return .notKnown
+        }
+    }
+}

--- a/RakutenRanking/ConfigViewController.swift
+++ b/RakutenRanking/ConfigViewController.swift
@@ -23,7 +23,7 @@ class ConfigViewController: UIViewController, UINavigationControllerDelegate {
     }
     
     @IBAction func chooseAge(_ sender: UISegmentedControl) {
-        ageType = getAgeBySelectNum(num: sender.selectedSegmentIndex)
+        ageType = Age.getAgeBySelectedNum(num: sender.selectedSegmentIndex)
     }
     
     @IBAction func saveSettings(_ sender: Any) {
@@ -55,20 +55,4 @@ class ConfigViewController: UIViewController, UINavigationControllerDelegate {
         }
     }
     
-    private func getAgeBySelectNum(num: Int) -> Age {
-        switch num {
-        case 1:
-            return Age.teens
-        case 2:
-            return Age.twenties
-        case 3:
-            return Age.thirties
-        case 4:
-            return Age.forties
-        case 5:
-            return Age.fiftiesOver
-        default:
-            return Age.notKnown
-        }
-    }
 }

--- a/RakutenRanking/ConfigViewController.swift
+++ b/RakutenRanking/ConfigViewController.swift
@@ -28,7 +28,7 @@ class ConfigViewController: UIViewController, UINavigationControllerDelegate {
     
     @IBAction func saveSettings(_ sender: Any) {
         // 選択した条件をアプリ起動時のランキングに反映させる
-        rankingManager.saveRankingTypeAtStartup(gender: self.genderType, age: self.ageType)
+        rankingManager.saveRankingTypeAtStartup(gender: self.genderType, age: self.ageType, pattern: ViewController.displayPattern)
     }
     
     @IBAction func cacheClearBtn() {

--- a/RakutenRanking/ConfigViewController.swift
+++ b/RakutenRanking/ConfigViewController.swift
@@ -82,12 +82,4 @@ class ConfigViewController: UIViewController, UINavigationControllerDelegate {
             return Age.notKnown
         }
     }
-    
-    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-        if let controller = viewController as? ViewController {
-            controller.gender = genderType
-            controller.age = ageType
-        }
-    }
-    
 }

--- a/RakutenRanking/ConfigViewController.swift
+++ b/RakutenRanking/ConfigViewController.swift
@@ -19,7 +19,7 @@ class ConfigViewController: UIViewController, UINavigationControllerDelegate {
     @IBOutlet weak var ageSegment: UISegmentedControl!
 
     @IBAction func chooseGender(_ sender: UISegmentedControl) {
-        genderType = getGenderBySelectNum(num: sender.selectedSegmentIndex)
+        genderType = Gender.setGenderBySelectedNum(num: sender.selectedSegmentIndex)
     }
     
     @IBAction func chooseAge(_ sender: UISegmentedControl) {
@@ -52,17 +52,6 @@ class ConfigViewController: UIViewController, UINavigationControllerDelegate {
         }
         if ageType != Age.notKnown {
             ageSegment.selectedSegmentIndex = ageType.rawValue / 10
-        }
-    }
-    
-    private func getGenderBySelectNum(num: Int) -> Gender {
-        switch num {
-        case 1:
-            return Gender.male
-        case 2:
-            return Gender.female
-        default:
-            return Gender.notKnown
         }
     }
     

--- a/RakutenRanking/DataGateway.swift
+++ b/RakutenRanking/DataGateway.swift
@@ -142,10 +142,11 @@ class DataGateway: DataGatewayProtocol {
         }
     }
     
-    func saveRankingType(genderType: Gender, ageType: Age) {
+    func saveRankingType(genderType: Gender, ageType: Age, displayPattern: Int) {
         // Key値を指定して保存
         userDefaults.set(genderType.rawValue, forKey: "genderType")
         userDefaults.set(ageType.rawValue, forKey: "ageType")
+        userDefaults.set(displayPattern, forKey: "displayPattern")
     }
     
     func getRankingType() -> (genderType: Gender, ageType: Age) {

--- a/RakutenRanking/DataGateway.swift
+++ b/RakutenRanking/DataGateway.swift
@@ -149,10 +149,11 @@ class DataGateway: DataGatewayProtocol {
         userDefaults.set(displayPattern, forKey: "displayPattern")
     }
     
-    func getRankingType() -> (genderType: Gender, ageType: Age) {
+    func getRankingType() -> (genderType: Gender, ageType: Age, displayPattern: Int) {
         // Key値を指定して値を取得
         let genderType: Gender = Gender(rawValue: userDefaults.integer(forKey: "genderType"))!
         let ageType: Age = Age(rawValue: userDefaults.integer(forKey: "ageType"))!
-        return(genderType, ageType)
+        let displayPattern: Int = userDefaults.integer(forKey: "displayPattern")
+        return(genderType, ageType, displayPattern)
     }
 }

--- a/RakutenRanking/DataGatewayProtocol.swift
+++ b/RakutenRanking/DataGatewayProtocol.swift
@@ -28,5 +28,5 @@ protocol DataGatewayProtocol {
     
     func saveRankingType(genderType: Gender, ageType: Age, displayPattern: Int)
     
-    func getRankingType() -> (genderType: Gender, ageType: Age)
+    func getRankingType() -> (genderType: Gender, ageType: Age, displayPattern: Int)
 }

--- a/RakutenRanking/DataGatewayProtocol.swift
+++ b/RakutenRanking/DataGatewayProtocol.swift
@@ -26,7 +26,7 @@ protocol DataGatewayProtocol {
     
     func deleteAllFavoriteObject()
     
-    func saveRankingType(genderType: Gender, ageType: Age)
+    func saveRankingType(genderType: Gender, ageType: Age, displayPattern: Int)
     
     func getRankingType() -> (genderType: Gender, ageType: Age)
 }

--- a/RakutenRanking/Gender.swift
+++ b/RakutenRanking/Gender.swift
@@ -1,0 +1,61 @@
+//
+//  Gender.swift
+//  RakutenRanking
+//
+//  Created by mao takagai on 2018/05/31.
+//  Copyright © 2018年 mao takagai. All rights reserved.
+//
+
+import Foundation
+
+enum Gender: Int {
+    
+    case notKnown = 0
+    case male = 1
+    case female = 2
+    
+    static func convertGenderToInt(gender: Gender) -> Int? {
+        switch gender {
+        case .male:
+            return 0
+        case .female:
+            return 1
+        default:
+            return nil
+        }
+    }
+    
+    static func convertGenderToString(gender: Gender) -> String {
+        switch gender {
+        case .male:
+             return "男性"
+        case .female:
+             return "女性"
+        default:
+             return ""
+        }
+    }
+    
+    static func setGenderByIndex(index: Int) -> Gender {
+        switch index {
+        case 0:
+            return .male
+        case 1:
+            return .female
+        default:
+            return .notKnown
+        }
+    }
+    
+    static func setGenderBySelectedNum(num: Int) -> Gender {
+        switch num {
+        case 1:
+            return .male
+        case 2:
+            return .female
+        default:
+            return .notKnown
+        }
+    }
+    
+}

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -105,7 +105,7 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
                 // チェックマークをつけた動作をセクション毎に変更する
                 switch indexPath.section {
                 case 0:
-                    self.setGender(index: indexPath.row)
+                    MenuViewController.gender = Gender.setGenderByIndex(index: indexPath.row)
                 case 1:
                     self.setAge(index: indexPath.row)
                 case 2:
@@ -138,17 +138,6 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
     }
     
-    private func setGender(index: Int) {
-        switch index {
-        case 0:
-            MenuViewController.gender = .male
-        case 1:
-            MenuViewController.gender = .female
-        default:
-            MenuViewController.gender = .notKnown
-        }
-    }
-    
     private func setAge(index: Int) {
         switch index {
         case 0:
@@ -163,17 +152,6 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
             MenuViewController.age = .fiftiesOver
         default:
             MenuViewController.age = .notKnown
-        }
-    }
-    
-    private func convertFrom(gender: Gender) -> Int? {
-        switch gender {
-        case .male:
-            return 0
-        case .female:
-            return 1
-        default:
-            return nil
         }
     }
 
@@ -203,7 +181,7 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     private func checkedRankingType(gender: Gender, age: Age) {
         if gender != .notKnown {
-            let indexPath = NSIndexPath(row: convertFrom(gender: gender)!, section: 0)
+            let indexPath = NSIndexPath(row: Gender.convertGenderToInt(gender: gender)!, section: 0)
             if let myCell = menuList.cellForRow(at: indexPath as IndexPath) {
                 myCell.accessoryType = .checkmark
             }

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -37,6 +37,8 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        // 起動時に表示する種別が総合でない場合は、該当の条件に予めチェックを入れておく
+        checkedRankingType(gender: MenuViewController.gender, age: MenuViewController.age)
         // リスト表示の行に予めチェックを入れておく
         checkedDisplayPattern()
     }
@@ -164,6 +166,34 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
     }
     
+    private func convertFrom(gender: Gender) -> Int? {
+        switch gender {
+        case .male:
+            return 0
+        case .female:
+            return 1
+        default:
+            return nil
+        }
+    }
+
+    private func convertFrom(age: Age) -> Int? {
+        switch age {
+        case .teens:
+            return 0
+        case .twenties:
+            return 1
+        case .thirties:
+            return 2
+        case .forties:
+            return 3
+        case .fiftiesOver:
+            return 4
+        default:
+            return nil
+        }
+    }
+
     private func checkedDisplayPattern() {
         let indexPath = NSIndexPath(row: MenuViewController.displayPattern, section: 2)
         if let myCell = menuList.cellForRow(at: indexPath as IndexPath) {
@@ -171,6 +201,21 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
         }
     }
     
+    private func checkedRankingType(gender: Gender, age: Age) {
+        if gender != .notKnown {
+            let indexPath = NSIndexPath(row: convertFrom(gender: gender)!, section: 0)
+            if let myCell = menuList.cellForRow(at: indexPath as IndexPath) {
+                myCell.accessoryType = .checkmark
+            }
+        }
+        if age != .notKnown {
+            let indexPath = NSIndexPath(row: convertFrom(age: age)!, section: 1)
+            if let myCell = menuList.cellForRow(at: indexPath as IndexPath) {
+                myCell.accessoryType = .checkmark
+            }
+        }
+    }
+
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }

--- a/RakutenRanking/MenuViewController.swift
+++ b/RakutenRanking/MenuViewController.swift
@@ -107,7 +107,7 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
                 case 0:
                     MenuViewController.gender = Gender.setGenderByIndex(index: indexPath.row)
                 case 1:
-                    self.setAge(index: indexPath.row)
+                    MenuViewController.age = Age.setAgeByIndex(index: indexPath.row)
                 case 2:
                     MenuViewController.displayPattern = indexPath.row
                 default:
@@ -137,40 +137,6 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
             }
         }
     }
-    
-    private func setAge(index: Int) {
-        switch index {
-        case 0:
-            MenuViewController.age = .teens
-        case 1:
-            MenuViewController.age = .twenties
-        case 2:
-            MenuViewController.age = .thirties
-        case 3:
-            MenuViewController.age = .forties
-        case 4:
-            MenuViewController.age = .fiftiesOver
-        default:
-            MenuViewController.age = .notKnown
-        }
-    }
-
-    private func convertFrom(age: Age) -> Int? {
-        switch age {
-        case .teens:
-            return 0
-        case .twenties:
-            return 1
-        case .thirties:
-            return 2
-        case .forties:
-            return 3
-        case .fiftiesOver:
-            return 4
-        default:
-            return nil
-        }
-    }
 
     private func checkedDisplayPattern() {
         let indexPath = NSIndexPath(row: MenuViewController.displayPattern, section: 2)
@@ -187,7 +153,7 @@ class MenuViewController: UIViewController, UITableViewDelegate, UITableViewData
             }
         }
         if age != .notKnown {
-            let indexPath = NSIndexPath(row: convertFrom(age: age)!, section: 1)
+            let indexPath = NSIndexPath(row: Age.convertAgeToInt(age: age)!, section: 1)
             if let myCell = menuList.cellForRow(at: indexPath as IndexPath) {
                 myCell.accessoryType = .checkmark
             }

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -8,16 +8,6 @@
 
 import Foundation
 
-enum Age: Int {
-    
-    case notKnown = 0
-    case teens = 10
-    case twenties = 20
-    case thirties = 30
-    case forties = 40
-    case fiftiesOver = 50
-}
-
 class RankingManager {
     
     private let rankingGateway: RankingGatewayProtocol = RankingGateway()

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -8,13 +8,6 @@
 
 import Foundation
 
-enum Gender: Int {
-    
-    case notKnown = 0
-    case male = 1
-    case female = 2
-}
-
 enum Age: Int {
     
     case notKnown = 0

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -59,8 +59,8 @@ class RankingManager {
         dataGateway.deleteAllFavoriteObject()
     }
     
-    func saveRankingTypeAtStartup(gender: Gender, age: Age) {
-        dataGateway.saveRankingType(genderType: gender, ageType: age)
+    func saveRankingTypeAtStartup(gender: Gender, age: Age, pattern: Int) {
+        dataGateway.saveRankingType(genderType: gender, ageType: age, displayPattern: pattern)
     }
     
     func getRankingTypeAtStartup() -> (gender: Gender, age: Age) {

--- a/RakutenRanking/RankingManager.swift
+++ b/RakutenRanking/RankingManager.swift
@@ -63,11 +63,13 @@ class RankingManager {
         dataGateway.saveRankingType(genderType: gender, ageType: age, displayPattern: pattern)
     }
     
-    func getRankingTypeAtStartup() -> (gender: Gender, age: Age) {
+    func getRankingTypeAtStartup() -> (gender: Gender, age: Age, pattern: Int) {
         let type = dataGateway.getRankingType()
         let gender = type.genderType
         let age = type.ageType
-        return(gender, age)
+        let pattern = type.displayPattern
+        
+        return(gender, age, pattern)
     }
 }
 

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -74,8 +74,10 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         let type = rankingManager.getRankingTypeAtStartup()
         self.gender = type.gender
         self.age = type.age
+        ViewController.displayPattern = type.pattern
         MenuViewController.gender = self.gender
         MenuViewController.age = self.age
+        MenuViewController.displayPattern = ViewController.displayPattern
         
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(refreshRanking(_:)), for: .valueChanged)
@@ -127,6 +129,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         self.collectionView.reloadData()
         self.removePageView()
         self.showPageView()
+        
+        setRankingPattern()
     }
     
     private func showMenu() {

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -107,23 +107,9 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     
     private func selectTitleByRankingType(_ gender: Gender, _ age: Age) -> String {
         let genderTitle = Gender.convertGenderToString(gender: gender)
-        let ageType: String
-        // 年代による分類
-        switch age {
-        case .teens:
-            ageType = "10代"
-        case .twenties:
-            ageType = "20代"
-        case .thirties:
-            ageType = "30代"
-        case .forties:
-            ageType = "40代"
-        case .fiftiesOver:
-            ageType = "50代以上"
-        default:
-            ageType = ""
-        }
-        return ageType + genderTitle
+        let ageTitle = Age.convertAgeToString(age: age)
+        
+        return ageTitle + genderTitle
     }
     
     // ランキングデータを取得し、配列に格納する

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -106,17 +106,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
     
     private func selectTitleByRankingType(_ gender: Gender, _ age: Age) -> String {
-        let genderType: String
+        let genderTitle = Gender.convertGenderToString(gender: gender)
         let ageType: String
-        // 性別による分類
-        switch gender {
-        case .male:
-            genderType = "男性"
-        case .female:
-            genderType = "女性"
-        default:
-            genderType = ""
-        }
         // 年代による分類
         switch age {
         case .teens:
@@ -132,7 +123,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         default:
             ageType = ""
         }
-        return ageType + genderType
+        return ageType + genderTitle
     }
     
     // ランキングデータを取得し、配列に格納する

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -74,6 +74,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         let type = rankingManager.getRankingTypeAtStartup()
         self.gender = type.gender
         self.age = type.age
+        MenuViewController.gender = self.gender
+        MenuViewController.age = self.age
         
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(refreshRanking(_:)), for: .valueChanged)

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -146,6 +146,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         self.rankingItemList = array
         self.mainRanking.reloadData()
         self.collectionView.reloadData()
+        self.removePageView()
+        self.showPageView()
     }
     
     private func showMenu() {

--- a/RakutenRanking/ViewController.swift
+++ b/RakutenRanking/ViewController.swift
@@ -56,7 +56,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     var gender: Gender = Gender.notKnown
     var age: Age = Age.notKnown
     // 表示方法のタイプを数値で保持
-    private var displayPattern: Int = 0
+    static var displayPattern: Int = 0
     
     // RankingManagerのインスタンス作成
     private let rankingManager = RankingManager()
@@ -140,8 +140,8 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
             getRankingItem(gender: gender, age: age)
         }
         
-        if self.displayPattern != MenuViewController.displayPattern {
-            self.displayPattern = MenuViewController.displayPattern
+        if ViewController.displayPattern != MenuViewController.displayPattern {
+            ViewController.displayPattern = MenuViewController.displayPattern
             setRankingPattern()
         }
         // ランキングタイトルを表示
@@ -149,7 +149,7 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
     }
     
     private func setRankingPattern() {
-        switch displayPattern {
+        switch ViewController.displayPattern {
         case 0:
             displayListView()
         case 1:


### PR DESCRIPTION
# issue 
#114 
#120 

# 対応した内容
* ページ表示の状態でメニューを開き、
種別を切り替えた後にメニューを閉じても反映されないバグへの対応

  -> メニューを閉じたタイミングで `更新されていない` のが原因だと判断したので
`viewDidLoad` で `pageView` を一度破棄してから再生成する処理を追加しました。
1. 起動
2. ページ表示に切り替え
3. メニューを開いて種別選択
4. メニューを閉じる
5. 種別が変更されていることを確認
　　
* 起動時に表示する種別を設定後にアプリを再起動し、
メニューを開いてそのまま閉じるとデフォルトの総合ランキングが表示されてしまうバグへの対応

  -> 起動時 `MenuViewController` では種別のセルにチェックが入っていない状態
（総合を選択している状態）になっており、なおかつメニューを閉じる際にはそのメニューの状態を `ViewController` に渡してランキングに反映させるような処理にしているのが原因だったため、
起動時の設定をランキングに反映させる時に `MenuViewController` にも起動時の設定を渡し、
メニュー内の選択状態（チェックマーク）も設定値に合わせて表示させるようにしました。
1. 起動
2. 設定画面にて起動時の種別を設定
3. アプリのタスクを切る
4. アプリ起動
5. メニューの開閉
6. 種別が変更されないことを確認
※ リスト/グリッド/ページ 全ての表示方法でバグが起きないことを確認済
　　
* 起動時に表示する種別を設定後にメイン画面でランキング情報を更新すると、起動時に表示させたい種別に切り替わるバグへの対応

  -> 設定画面を閉じる際、設定値を `ViewController` に渡してしまっていたことが原因だったので
値を渡しているメソッドを削除しました。
1. 起動
2. 設定画面にて起動時の種別を設定
3. ランキング表示画面に戻る
4. ランキングを更新
5. 種別が変更されないことを確認
※ リスト/グリッド 表示にて確認済